### PR TITLE
Rehomed command-classes so that Clamp would work correctly

### DIFF
--- a/lib/hammer_cli_csv.rb
+++ b/lib/hammer_cli_csv.rb
@@ -14,9 +14,9 @@ require 'hammer_cli/exit_codes'
 
 module HammerCLICsv
 
-  def self.exception_handler_class
-    HammerCLICsv::ExceptionHandler
-  end
+  #def self.exception_handler_class
+  #  HammerCLICsv::ExceptionHandler
+  #end
 
   require 'hammer_cli_csv/base'
   require 'hammer_cli_csv/exception_handler'
@@ -24,26 +24,24 @@ module HammerCLICsv
   require 'hammer_cli_csv/csv'
   require 'hammer_cli_csv/activation_keys'
   require 'hammer_cli_csv/architectures'
+  require 'hammer_cli_csv/content_views'
   require 'hammer_cli_csv/domains'
   require 'hammer_cli_csv/hosts'
+  require 'hammer_cli_csv/lifecycle_environments'
   require 'hammer_cli_csv/locations'
   require 'hammer_cli_csv/operating_systems'
   require 'hammer_cli_csv/organizations'
   require 'hammer_cli_csv/partition_tables'
   require 'hammer_cli_csv/permissions'
+  require 'hammer_cli_csv/products'
   require 'hammer_cli_csv/puppet_environments'
   require 'hammer_cli_csv/puppet_facts'
   require 'hammer_cli_csv/puppet_reports'
   require 'hammer_cli_csv/reports'
   require 'hammer_cli_csv/roles'
-  require 'hammer_cli_csv/system_groups'
-  require 'hammer_cli_csv/users'
-
-  require 'hammer_cli_csv/activation_keys'
-  require 'hammer_cli_csv/content_views'
-  require 'hammer_cli_csv/lifecycle_environments'
-  require 'hammer_cli_csv/products'
   require 'hammer_cli_csv/subscriptions'
   require 'hammer_cli_csv/systems'
   require 'hammer_cli_csv/system_groups'
+  require 'hammer_cli_csv/users'
+
 end

--- a/lib/hammer_cli_csv/activation_keys.rb
+++ b/lib/hammer_cli_csv/activation_keys.rb
@@ -29,88 +29,80 @@ require 'json'
 require 'csv'
 
 module HammerCLICsv
-  class ActivationKeysCommand < BaseCommand
+  class CsvCommand
+    class ActivationKeysCommand < BaseCommand
 
-    ORGANIZATION = 'Organization'
-    DESCRIPTION = 'Description'
-    LIMIT = 'Limit'
-    ENVIRONMENT = 'Environment'
-    CONTENTVIEW = 'Content View'
-    SYSTEMGROUPS = 'System Groups'
-    SUBSCRIPTIONS = 'Subscriptions'
+      command_name "activation-keys"
+      desc         "import or export activation keys"
 
-    def export
-      CSV.open(option_csv_file || '/dev/stdout', 'wb', {:force_quotes => false}) do |csv|
-        csv << [NAME, COUNT, ORGANIZATION, DESCRIPTION, LIMIT, ENVIRONMENT, CONTENTVIEW,
-                SYSTEMGROUPS, SUBSCRIPTIONS]
-        @api.resource(:organizations).call(:index, {:per_page => 999999})['results'].each do |organization|
-          @api.resource(:activation_keys).call(:index, {'per_page' => 999999,
-                                       'organization_id' => organization['label']
-                                     })['results'].each do |activationkey|
-            puts "Writing activation key '#{activationkey['name']}'" if option_verbose?
-            name = namify(activationkey['name'])
-            count = 1
-            description = activationkey['description']
-            limit = activationkey['usage_limit'].to_i < 0 ? 'Unlimited' : sytemgroup['usage_limit']
-            environment = activationkey['environment']['label']
-            contentview = activationkey['content_view']['name']
-            systemgroups = CSV.generate do |column|
-              column << activationkey['systemGroups'].collect do |systemgroup|
-                systemgroup['name']
-              end
-            end.delete!("\n") if activationkey['systemGroups']
-            subscriptions = CSV.generate do |column|
-              column << @api.resource(:subscriptions).call(:index, {
-                                                    'activation_key_id' => activationkey['id']
-                                                  })['results'].collect do |subscription|
-                amount = subscription['amount'] == 0 ? 'Automatic' : subscription['amount']
-                "#{amount}|#{subscription['product_name']}"
-              end
-            end.delete!("\n")
-            csv << [name, count, organization['label'], description, limit, environment, contentview,
-                    systemgroups, subscriptions]
+      ORGANIZATION = 'Organization'
+      DESCRIPTION = 'Description'
+      LIMIT = 'Limit'
+      ENVIRONMENT = 'Environment'
+      CONTENTVIEW = 'Content View'
+      SYSTEMGROUPS = 'System Groups'
+      SUBSCRIPTIONS = 'Subscriptions'
+
+      def export
+        CSV.open(option_csv_file || '/dev/stdout', 'wb', {:force_quotes => false}) do |csv|
+          csv << [NAME, COUNT, ORGANIZATION, DESCRIPTION, LIMIT, ENVIRONMENT, CONTENTVIEW,
+                  SYSTEMGROUPS, SUBSCRIPTIONS]
+          @api.resource(:organizations).call(:index, {:per_page => 999999})['results'].each do |organization|
+            @api.resource(:activation_keys).call(:index, {'per_page' => 999999,
+                                         'organization_id' => organization['label']
+                                       })['results'].each do |activationkey|
+              puts "Writing activation key '#{activationkey['name']}'" if option_verbose?
+              name = namify(activationkey['name'])
+              count = 1
+              description = activationkey['description']
+              limit = activationkey['usage_limit'].to_i < 0 ? 'Unlimited' : sytemgroup['usage_limit']
+              environment = activationkey['environment']['label']
+              contentview = activationkey['content_view']['name']
+              systemgroups = CSV.generate do |column|
+                column << activationkey['systemGroups'].collect do |systemgroup|
+                  systemgroup['name']
+                end
+              end.delete!("\n") if activationkey['systemGroups']
+              subscriptions = CSV.generate do |column|
+                column << @api.resource(:subscriptions).call(:index, {
+                                                      'activation_key_id' => activationkey['id']
+                                                    })['results'].collect do |subscription|
+                  amount = subscription['amount'] == 0 ? 'Automatic' : subscription['amount']
+                  "#{amount}|#{subscription['product_name']}"
+                end
+              end.delete!("\n")
+              csv << [name, count, organization['label'], description, limit, environment, contentview,
+                      systemgroups, subscriptions]
+            end
           end
         end
       end
-    end
 
-    def import
-      @existing = {}
+      def import
+        @existing = {}
 
-      thread_import do |line|
-        create_activationkeys_from_csv(line)
-      end
-    end
-
-    def create_activationkeys_from_csv(line)
-      if !@existing[line[ORGANIZATION]]
-        @existing[line[ORGANIZATION]] = {}
-        @api.resource(:activation_keys).call(:index, {
-                                     'per_page' => 999999,
-                                     'organization_id' => katello_organization(:name => line[ORGANIZATION])
-                                   })['results'].each do |activationkey|
-          @existing[line[ORGANIZATION]][activationkey['name']] = activationkey['id'] if activationkey
+        thread_import do |line|
+          create_activationkeys_from_csv(line)
         end
       end
 
-      line[COUNT].to_i.times do |number|
-        name = namify(line[NAME], number)
+      def create_activationkeys_from_csv(line)
+        if !@existing[line[ORGANIZATION]]
+          @existing[line[ORGANIZATION]] = {}
+          @api.resource(:activation_keys).call(:index, {
+                                       'per_page' => 999999,
+                                       'organization_id' => katello_organization(:name => line[ORGANIZATION])
+                                     })['results'].each do |activationkey|
+            @existing[line[ORGANIZATION]][activationkey['name']] = activationkey['id'] if activationkey
+          end
+        end
 
-        if !@existing[line[ORGANIZATION]].include? name
-          print "Creating activation key '#{name}'..." if option_verbose?
-          activationkey = @api.resource(:activation_keys).call(:create, {
-                                      'name' => name,
-                                      'environment_id' => katello_environment(line[ORGANIZATION],
-                                                                              :name => line[ENVIRONMENT]),
-                                      'content_view_id' => katello_contentview(line[ORGANIZATION],
-                                                                               :name => line[CONTENTVIEW]),
-                                      'description' => line[DESCRIPTION]
-                                    })
-          @existing[line[ORGANIZATION]][activationkey['name']] = activationkey['id']
-        else
-          print "Updating activation key '#{name}'..." if option_verbose?
-          activationkey = @api.resource(:activation_keys).call(:update, {
-                                        'id' => @existing[line[ORGANIZATION]][name],
+        line[COUNT].to_i.times do |number|
+          name = namify(line[NAME], number)
+
+          if !@existing[line[ORGANIZATION]].include? name
+            print "Creating activation key '#{name}'..." if option_verbose?
+            activationkey = @api.resource(:activation_keys).call(:create, {
                                         'name' => name,
                                         'environment_id' => katello_environment(line[ORGANIZATION],
                                                                                 :name => line[ENVIRONMENT]),
@@ -118,59 +110,68 @@ module HammerCLICsv
                                                                                  :name => line[CONTENTVIEW]),
                                         'description' => line[DESCRIPTION]
                                       })
+            @existing[line[ORGANIZATION]][activationkey['name']] = activationkey['id']
+          else
+            print "Updating activation key '#{name}'..." if option_verbose?
+            activationkey = @api.resource(:activation_keys).call(:update, {
+                                          'id' => @existing[line[ORGANIZATION]][name],
+                                          'name' => name,
+                                          'environment_id' => katello_environment(line[ORGANIZATION],
+                                                                                  :name => line[ENVIRONMENT]),
+                                          'content_view_id' => katello_contentview(line[ORGANIZATION],
+                                                                                   :name => line[CONTENTVIEW]),
+                                          'description' => line[DESCRIPTION]
+                                        })
+          end
+
+          update_subscriptions(activationkey, line)
+          update_groups(activationkey, line)
+
+          puts "done" if option_verbose?
         end
-
-        update_subscriptions(activationkey, line)
-        update_groups(activationkey, line)
-
-        puts "done" if option_verbose?
       end
-    end
 
-    def update_groups(activationkey, line)
-      if line[SYSTEMGROUPS] && line[SYSTEMGROUPS] != ''
-        # TODO: note that existing system groups are not removed
-        CSV.parse_line(line[SYSTEMGROUPS], {:skip_blanks => true}).each do |name|
-          @api.resource(:system_groups).call(:add_activation_keys, {
-                                                   'id' => katello_systemgroup(line[ORGANIZATION], :name => name),
-                                                   'activation_key_ids' => [activationkey['id']]
-                                                 })
+      def update_groups(activationkey, line)
+        if line[SYSTEMGROUPS] && line[SYSTEMGROUPS] != ''
+          # TODO: note that existing system groups are not removed
+          CSV.parse_line(line[SYSTEMGROUPS], {:skip_blanks => true}).each do |name|
+            @api.resource(:system_groups).call(:add_activation_keys, {
+                                                     'id' => katello_systemgroup(line[ORGANIZATION], :name => name),
+                                                     'activation_key_ids' => [activationkey['id']]
+                                                   })
+          end
         end
       end
-    end
 
-    def update_subscriptions(activationkey, line)
-      if line[SUBSCRIPTIONS] && line[SUBSCRIPTIONS] != ''
-        subscriptions = CSV.parse_line(line[SUBSCRIPTIONS], {:skip_blanks => true}).collect do |subscription_details|
-          subscription = {}
-          (amount, name) = subscription_details.split('|')
-          {
-            :id => katello_subscription(line[ORGANIZATION], :name => name),
-            :quantity => amount
-           }
-        end
+      def update_subscriptions(activationkey, line)
+        if line[SUBSCRIPTIONS] && line[SUBSCRIPTIONS] != ''
+          subscriptions = CSV.parse_line(line[SUBSCRIPTIONS], {:skip_blanks => true}).collect do |subscription_details|
+            subscription = {}
+            (amount, name) = subscription_details.split('|')
+            {
+              :id => katello_subscription(line[ORGANIZATION], :name => name),
+              :quantity => amount
+             }
+          end
 
-        # TODO: should there be a destroy_all similar to systems?
-        @api.resource(:subscriptions).call(:index, {
-                                             'per_page' => 999999,
-                                             'activation_key_id' => activationkey['id']
-                                           })['results'].each do |subscription|
-          @api.resource(:subscriptions).call(:destroy, {
-                                               'id' => subscription['id'],
+          # TODO: should there be a destroy_all similar to systems?
+          @api.resource(:subscriptions).call(:index, {
+                                               'per_page' => 999999,
                                                'activation_key_id' => activationkey['id']
+                                             })['results'].each do |subscription|
+            @api.resource(:subscriptions).call(:destroy, {
+                                                 'id' => subscription['id'],
+                                                 'activation_key_id' => activationkey['id']
+                                               })
+          end
+
+          @api.resource(:subscriptions).call(:create, {
+                                               'activation_key_id' => activationkey['id'],
+                                               'subscriptions' => subscriptions
                                              })
         end
-
-        @api.resource(:subscriptions).call(:create, {
-                                             'activation_key_id' => activationkey['id'],
-                                             'subscriptions' => subscriptions
-                                           })
       end
     end
 
   end
-
-  HammerCLICsv::CsvCommand.subcommand("activation-keys",
-                                      "import or export activation keys",
-                                      HammerCLICsv::ActivationKeysCommand)
 end

--- a/lib/hammer_cli_csv/base.rb
+++ b/lib/hammer_cli_csv/base.rb
@@ -17,14 +17,6 @@ require 'hammer_cli_csv/csv'
 
 module HammerCLICsv
   class BaseCommand < HammerCLI::Apipie::Command
-    NAME = 'Name'
-    COUNT = 'Count'
-
-    def request_help(help_command = 'hammer csv', help_options = '')
-      puts "TODO: write some help!"
-      exit(HammerCLI::EX_OK)
-    end
-
     option %w(-v --verbose), :flag, 'be verbose'
     option %w(--threads), 'THREAD_COUNT', 'Number of threads to hammer with', :default => 1
     option %w(--csv-export), :flag, 'Export current data instead of importing'
@@ -33,6 +25,9 @@ module HammerCLICsv
     option %w(--server), 'SERVER', 'Server URL'
     option %w(-u --username), 'USERNAME', 'Username to access server'
     option %w(-p --password), 'PASSWORD', 'Password to access server'
+
+    NAME = 'Name'
+    COUNT = 'Count'
 
     def execute
       if !option_csv_file

--- a/lib/hammer_cli_csv/content_views.rb
+++ b/lib/hammer_cli_csv/content_views.rb
@@ -27,83 +27,84 @@ require 'csv'
 require 'uri'
 
 module HammerCLICsv
-  class ContentViewsCommand < BaseCommand
+  class CsvCommand
+    class ContentViewsCommand < BaseCommand
+      command_name "content-views"
+      desc         "import or export content-views"
 
-    ORGANIZATION = 'Organization'
-    DESCRIPTION = 'Description'
-    PRODUCT = 'Product'
-    REPOSITORY = 'Repository'
 
-    def export
-      # TODO
-    end
+      ORGANIZATION = 'Organization'
+      DESCRIPTION = 'Description'
+      PRODUCT = 'Product'
+      REPOSITORY = 'Repository'
 
-    def import
-      @existing_contentviews = {}
-
-      thread_import do |line|
-        create_contentviews_from_csv(line)
+      def export
+        # TODO
       end
-    end
 
-    def create_contentviews_from_csv(line)
-      if !@existing_contentviews[line[ORGANIZATION]]
-        @existing_contentviews[line[ORGANIZATION]] ||= {}
-        @api.resource(:contentviewdefinitions).call(:index, {'organization_id' => line[ORGANIZATION], 'page_size' => 999999, 'paged' => true})['results'].each do |contentview|
-          @existing_contentviews[line[ORGANIZATION]][contentview['name']] = contentview['id'] if contentview
+      def import
+        @existing_contentviews = {}
+
+        thread_import do |line|
+          create_contentviews_from_csv(line)
         end
       end
 
-      line[COUNT].to_i.times do |number|
-        name = namify(line[NAME], number)
-        contentview_id = @existing_contentviews[line[ORGANIZATION]][name]
-        if !contentview_id
-          print "Creating content view '#{name}'..." if option_verbose?
-          contentview_id = @api.resource(:contentviewdefinitions).call(:create, {
-                                                                 'organization_id' => line[ORGANIZATION],
-                                                                 'name' => name,
-                                                                 'label' => labelize(name),
-                                                                 'description' => line[DESCRIPTION],
-                                                                 'composite' => false # TODO: add column?
-                                                               })['id']
-          @existing_contentviews[line[ORGANIZATION]][name] = contentview_id
-        else
-          print "Updating content view '#{name}'..." if option_verbose?
-          @api.resource(:contentviewdefinitions).call(:create, {
-                                                'description' => line[DESCRIPTION],
-                                              })
+      def create_contentviews_from_csv(line)
+        if !@existing_contentviews[line[ORGANIZATION]]
+          @existing_contentviews[line[ORGANIZATION]] ||= {}
+          @api.resource(:contentviewdefinitions).call(:index, {'organization_id' => line[ORGANIZATION], 'page_size' => 999999, 'paged' => true})['results'].each do |contentview|
+            @existing_contentviews[line[ORGANIZATION]][contentview['name']] = contentview['id'] if contentview
+          end
         end
 
-        if line[REPOSITORY]
-          puts "UPDATING REPOSITORY"
-        elsif line[PRODUCT]
-          puts "UPDATING PRODUCT"
-        end
-        print "done\n" if option_verbose?
+        line[COUNT].to_i.times do |number|
+          name = namify(line[NAME], number)
+          contentview_id = @existing_contentviews[line[ORGANIZATION]][name]
+          if !contentview_id
+            print "Creating content view '#{name}'..." if option_verbose?
+            contentview_id = @api.resource(:contentviewdefinitions).call(:create, {
+                                                                   'organization_id' => line[ORGANIZATION],
+                                                                   'name' => name,
+                                                                   'label' => labelize(name),
+                                                                   'description' => line[DESCRIPTION],
+                                                                   'composite' => false # TODO: add column?
+                                                                 })['id']
+            @existing_contentviews[line[ORGANIZATION]][name] = contentview_id
+          else
+            print "Updating content view '#{name}'..." if option_verbose?
+            @api.resource(:contentviewdefinitions).call(:create, {
+                                                  'description' => line[DESCRIPTION],
+                                                })
+          end
+
+          if line[REPOSITORY]
+            puts "UPDATING REPOSITORY"
+          elsif line[PRODUCT]
+            puts "UPDATING PRODUCT"
+          end
+          print "done\n" if option_verbose?
 
 =begin
-        # Only creating repositories, not updating
-        repository_name = namify(line[REPOSITORY], number)
-        if !@existing_repositories[line[ORGANIZATION] + name][labelize(repository_name)]
-          print "Creating repository '#{repository_name}' in contentview '#{name}'..." if option_verbose?
-          @api.resource(:repositorys).call(:create, {
-                                     'name' => repository_name,
-                                     'label' => labelize(repository_name),
-                                     'contentview_id' => contentview_id,
-                                     'url' => line[REPOSITORY_URL],
-                                     'content_type' => line[REPOSITORY_TYPE]
-                                   })
-          print "done\n" if option_verbose?
-        end
+          # Only creating repositories, not updating
+          repository_name = namify(line[REPOSITORY], number)
+          if !@existing_repositories[line[ORGANIZATION] + name][labelize(repository_name)]
+            print "Creating repository '#{repository_name}' in contentview '#{name}'..." if option_verbose?
+            @api.resource(:repositorys).call(:create, {
+                                       'name' => repository_name,
+                                       'label' => labelize(repository_name),
+                                       'contentview_id' => contentview_id,
+                                       'url' => line[REPOSITORY_URL],
+                                       'content_type' => line[REPOSITORY_TYPE]
+                                     })
+            print "done\n" if option_verbose?
+          end
 =end
-      end
+        end
 
-    rescue RuntimeError => e
-      raise "#{e}\n       #{line}"
+      rescue RuntimeError => e
+        raise "#{e}\n       #{line}"
+      end
     end
   end
-
-  HammerCLICsv::CsvCommand.subcommand("content-views",
-                                      "import or export content-views",
-                                      HammerCLICsv::ContentViewsCommand)
 end

--- a/lib/hammer_cli_csv/csv.rb
+++ b/lib/hammer_cli_csv/csv.rb
@@ -15,10 +15,6 @@ require 'hammer_cli/exit_codes'
 
 module HammerCLICsv
   class CsvCommand < HammerCLI::AbstractCommand
-    # def request_help
-    #   puts _("import to, or export from a running foretello server")
-    #   exit(HammerCLI::EX_OK)
-    # end
   end
 
   HammerCLI::MainCommand.subcommand("csv",

--- a/lib/hammer_cli_csv/lifecycle_environments.rb
+++ b/lib/hammer_cli_csv/lifecycle_environments.rb
@@ -26,86 +26,87 @@ require 'json'
 require 'csv'
 
 module HammerCLICsv
-  class LifecycleEnvironmentsCommand < BaseCommand
+  class CsvCommand
+    class LifecycleEnvironmentsCommand < BaseCommand
 
-    LABEL = "Label"
-    ORGANIZATION = "Organization"
-    PRIORENVIRONMENT = "Prior Environment"
-    DESCRIPTION = "Description"
+      command_name "lifecycle-environment"
+      desc         "import or export lifecycle environments"
 
-    def export
-      CSV.open(option_csv_file || '/dev/stdout', 'wb', {:force_quotes => true}) do |csv|
-        csv << [NAME, COUNT, LABEL, ORGANIZATION, PRIORENVIRONMENT, DESCRIPTION]
-        @api.resource(:organizations).call(:index, {'per_page' => 999999})['results'].each do |organization|
-          @api.resource(:environments).call(:index, {
-                                     'per_page' => 999999,
-                                     'organization_id' => organization['label']
-                                   })['results'].each do |environment|
-            if environment['label'] != 'Library'
-              name = environment['name']
-              count = 1
-              label = environment['label']
-              prior = environment['prior']
-              description = environment['description']
-              csv << [name, count, label, organization['name'], prior, description]
+      LABEL = "Label"
+      ORGANIZATION = "Organization"
+      PRIORENVIRONMENT = "Prior Environment"
+      DESCRIPTION = "Description"
+
+      def export
+        CSV.open(option_csv_file || '/dev/stdout', 'wb', {:force_quotes => true}) do |csv|
+          csv << [NAME, COUNT, LABEL, ORGANIZATION, PRIORENVIRONMENT, DESCRIPTION]
+          @api.resource(:organizations).call(:index, {'per_page' => 999999})['results'].each do |organization|
+            @api.resource(:environments).call(:index, {
+                                       'per_page' => 999999,
+                                       'organization_id' => organization['label']
+                                     })['results'].each do |environment|
+              if environment['label'] != 'Library'
+                name = environment['name']
+                count = 1
+                label = environment['label']
+                prior = environment['prior']
+                description = environment['description']
+                csv << [name, count, label, organization['name'], prior, description]
+              end
             end
           end
         end
       end
-    end
 
-    def import
-      @existing = {}
-      @api.resource(:organizations).call(:index, {'per_page' => 999999})['results'].each do |organization|
-        @api.resource(:environments).call(:index, {
-                                   'per_page' => 999999,
-                                   'organization_id' => katello_organization(:name => organization['name']),
-                                   'library' => true
-                                 })['results'].each do |environment|
-          @existing[organization['name']] ||= {}
-          @existing[organization['name']][environment['name']] = environment['id'] if environment
+      def import
+        @existing = {}
+        @api.resource(:organizations).call(:index, {'per_page' => 999999})['results'].each do |organization|
+          @api.resource(:environments).call(:index, {
+                                     'per_page' => 999999,
+                                     'organization_id' => katello_organization(:name => organization['name']),
+                                     'library' => true
+                                   })['results'].each do |environment|
+            @existing[organization['name']] ||= {}
+            @existing[organization['name']][environment['name']] = environment['id'] if environment
+          end
+        end
+
+        thread_import do |line|
+          create_environments_from_csv(line)
         end
       end
 
-      thread_import do |line|
-        create_environments_from_csv(line)
-      end
-    end
-
-    def create_environments_from_csv(line)
-      line[COUNT].to_i.times do |number|
-        name = namify(line[NAME], number)
-        label = namify(line[LABEL], number)
-        prior = namify(line[PRIORENVIRONMENT], number)
-        raise "Organization '#{line[ORGANIZATION]}' does not exist" if !@existing.include? line[ORGANIZATION]
-        if !@existing[line[ORGANIZATION]].include? name
-          print "Creating environment '#{name}'..." if option_verbose?
-          @api.resource(:environments).call(:create, {
-                                      'organization_id' => katello_organization(:name => line[ORGANIZATION]),
-                                      'name' => name,
-                                      'label' => label,
-                                      'prior' => katello_environment(line[ORGANIZATION], :name => prior),
-                                      'description' => line[DESCRIPTION]
-                                    })
-        else
-          print "Updating environment '#{name}'..." if option_verbose?
-          @api.resource(:environments).call(:update, {
-                                      'id' => @existing[line[ORGANIZATION]][name],
-                                      'name' => name,
-                                      'new_name' => name,
-                                      'organization_id' => katello_organization(:name => line[ORGANIZATION]),
-                                      'prior' => prior,
-                                      'description' => line[DESCRIPTION]
-                                    })
+      def create_environments_from_csv(line)
+        line[COUNT].to_i.times do |number|
+          name = namify(line[NAME], number)
+          label = namify(line[LABEL], number)
+          prior = namify(line[PRIORENVIRONMENT], number)
+          raise "Organization '#{line[ORGANIZATION]}' does not exist" if !@existing.include? line[ORGANIZATION]
+          if !@existing[line[ORGANIZATION]].include? name
+            print "Creating environment '#{name}'..." if option_verbose?
+            @api.resource(:environments).call(:create, {
+                                        'organization_id' => katello_organization(:name => line[ORGANIZATION]),
+                                        'name' => name,
+                                        'label' => label,
+                                        'prior' => katello_environment(line[ORGANIZATION], :name => prior),
+                                        'description' => line[DESCRIPTION]
+                                      })
+          else
+            print "Updating environment '#{name}'..." if option_verbose?
+            @api.resource(:environments).call(:update, {
+                                        'id' => @existing[line[ORGANIZATION]][name],
+                                        'name' => name,
+                                        'new_name' => name,
+                                        'organization_id' => katello_organization(:name => line[ORGANIZATION]),
+                                        'prior' => prior,
+                                        'description' => line[DESCRIPTION]
+                                      })
+          end
+          print "done\n" if option_verbose?
         end
-        print "done\n" if option_verbose?
+      rescue RuntimeError => e
+        raise "#{e}\n       #{line}"
       end
-    rescue RuntimeError => e
-      raise "#{e}\n       #{line}"
     end
   end
-
-  HammerCLICsv::CsvCommand.subcommand("lifecycle-environment",
-                                      "import or export lifecycle environments",
-                                      HammerCLICsv::LifecycleEnvironmentsCommand)
 end

--- a/lib/hammer_cli_csv/organizations.rb
+++ b/lib/hammer_cli_csv/organizations.rb
@@ -31,54 +31,55 @@ require 'json'
 require 'csv'
 
 module HammerCLICsv
-  class OrganizationsCommand < BaseCommand
-    ORGLABEL = 'Org Label'
-    DESCRIPTION = 'Description'
+  class CsvCommand
+    class OrganizationsCommand < BaseCommand
+      command_name 'organizations'
+      desc         'import or export organizations'
 
-    def export
-      CSV.open(option_csv_file || '/dev/stdout', 'wb', {:force_quotes => true}) do |csv|
-        csv << [NAME, COUNT, ORGLABEL, DESCRIPTION]
+      ORGLABEL = 'Org Label'
+      DESCRIPTION = 'Description'
+
+      def export
+        CSV.open(option_csv_file || '/dev/stdout', 'wb', {:force_quotes => true}) do |csv|
+          csv << [NAME, COUNT, ORGLABEL, DESCRIPTION]
+          @api.resource(:organizations).call(:index, {:per_page => 999999})['results'].each do |organization|
+            csv << [organization['name'], 1, organization['label'], organization['description']]
+          end
+        end
+      end
+
+      def import
+        @existing = {}
         @api.resource(:organizations).call(:index, {:per_page => 999999})['results'].each do |organization|
-          csv << [organization['name'], 1, organization['label'], organization['description']]
+          @existing[organization['name']] = organization['label'] if organization
+        end
+
+        thread_import do |line|
+          create_organizations_from_csv(line)
         end
       end
-    end
 
-    def import
-      @existing = {}
-      @api.resource(:organizations).call(:index, {:per_page => 999999})['results'].each do |organization|
-        @existing[organization['name']] = organization['label'] if organization
-      end
-
-      thread_import do |line|
-        create_organizations_from_csv(line)
-      end
-    end
-
-    def create_organizations_from_csv(line)
-      line[COUNT].to_i.times do |number|
-        name = namify(line[NAME], number)
-        label = namify(line[ORGLABEL], number)
-        if !@existing.include? name
-          print "Creating organization '#{name}'... " if option_verbose?
-          @api.resource(:organizations).call(:create, {
-                                       'name' => name,
-                                       'label' => label,
-                                       'description' => line[DESCRIPTION]
-                                     })
-        else
-          print "Updating organization '#{name}'... " if option_verbose?
-          @api.resource(:organizations).call(:update, {
-                                       'id' => label,
-                                       'description' => line[DESCRIPTION]
-                                     })
+      def create_organizations_from_csv(line)
+        line[COUNT].to_i.times do |number|
+          name = namify(line[NAME], number)
+          label = namify(line[ORGLABEL], number)
+          if !@existing.include? name
+            print "Creating organization '#{name}'... " if option_verbose?
+            @api.resource(:organizations).call(:create, {
+                                         'name' => name,
+                                         'label' => label,
+                                         'description' => line[DESCRIPTION]
+                                       })
+          else
+            print "Updating organization '#{name}'... " if option_verbose?
+            @api.resource(:organizations).call(:update, {
+                                         'id' => label,
+                                         'description' => line[DESCRIPTION]
+                                       })
+          end
+          print "done\n" if option_verbose?
         end
-        print "done\n" if option_verbose?
       end
     end
   end
-
-  HammerCLICsv::CsvCommand.subcommand('organizations',
-                                      'import or export organizations',
-                                      HammerCLICsv::OrganizationsCommand)
 end

--- a/lib/hammer_cli_csv/permissions.rb
+++ b/lib/hammer_cli_csv/permissions.rb
@@ -22,7 +22,7 @@
 #   Role
 #   Description
 #   Category
-#     - organizations, environments, activation_keys, system_groups, providers, users, roles, 
+#     - organizations, environments, activation_keys, system_groups, providers, users, roles,
 #       content_view_definitions, content_views, all
 #   Verbs
 #     organizations - gpg, redhat_products, delete_distributors, delete_systems, manage_nodes,
@@ -46,101 +46,102 @@ require 'json'
 require 'csv'
 
 module HammerCLICsv
-  class PermissionsCommand < BaseCommand
+  class CsvCommand
+    class PermissionsCommand < BaseCommand
 
-    def initialize(*args)
-      super(args)
-      @role_api = KatelloApi::Resources::Role.new(@init_options)
-      @permission_api = KatelloApi::Resources::Permission.new(@init_options)
-    end
+      command_name "permissions"
+      desc         "import or export permissions"
 
-    def export
-      # TODO
-    end
-
-    def import
-      csv = get_lines(option_csv_file)[1..-1]
-      lines_per_thread = csv.length/threads.to_i + 1
-      splits = []
-
-      @roles = {}
-      @role_api.index[0].each do |role|
-          @roles[role['name']] = role['id']
+      def initialize(*args)
+        super(args)
+        @role_api = KatelloApi::Resources::Role.new(@init_options)
+        @permission_api = KatelloApi::Resources::Permission.new(@init_options)
       end
 
-      @verbs = {}
-      puts @role_api.available_verbs[0]
-      return HammerCLI::EX_OK
-      @role_api.available_verbs[0].each do |verb|
-          @verbs[verb['name']] = verb['id']
+      def export
+        # TODO
       end
 
-      puts @verbs
-      return
+      def import
+        csv = get_lines(option_csv_file)[1..-1]
+        lines_per_thread = csv.length/threads.to_i + 1
+        splits = []
 
-      @existing = {}
+        @roles = {}
+        @role_api.index[0].each do |role|
+            @roles[role['name']] = role['id']
+        end
 
-      threads.to_i.times do |current_thread|
-        start_index = ((current_thread) * lines_per_thread).to_i
-        finish_index = ((current_thread + 1) * lines_per_thread).to_i
-        lines = csv[start_index...finish_index].clone
-        splits << Thread.new do
-          lines.each do |line|
-            if line.index('#') != 0
-              create_permissions_from_csv(line)
+        @verbs = {}
+        puts @role_api.available_verbs[0]
+        return HammerCLI::EX_OK
+        @role_api.available_verbs[0].each do |verb|
+            @verbs[verb['name']] = verb['id']
+        end
+
+        puts @verbs
+        return
+
+        @existing = {}
+
+        threads.to_i.times do |current_thread|
+          start_index = ((current_thread) * lines_per_thread).to_i
+          finish_index = ((current_thread + 1) * lines_per_thread).to_i
+          lines = csv[start_index...finish_index].clone
+          splits << Thread.new do
+            lines.each do |line|
+              if line.index('#') != 0
+                create_permissions_from_csv(line)
+              end
             end
+          end
+        end
+
+        splits.each do |thread|
+          thread.join
+        end
+
+        HammerCLI::EX_OK
+      end
+
+      def create_permissions_from_csv(line)
+        details = parse_permission_csv(line)
+
+        puts @permission_api.index({'role_id' => @roles['User System Group']})
+        # {"all_tags"=>false, "all_verbs"=>false, "created_at"=>"2013-11-11T02:31:23Z", "description"=>"and it's description!", "id"=>12, "name"=>"Accounting System Group Modify Systems", "organization_id"=>2, "resource_type_id"=>5, "role_id"=>124, "updated_at"=>"2013-11-11T02:31:23Z", "tags"=>[{"created_at"=>"2013-11-11T02:31:23Z", "formatted"=>{"name"=>6, "display_name"=>"Accounting"}, "id"=>2, "permission_id"=>12, "tag_id"=>6, "updated_at"=>"2013-11-11T02:31:23Z"}], "verbs"=>[{"created_at"=>"2013-11-07T19:44:45Z", "id"=>7, "updated_at"=>"2013-11-07T19:44:45Z", "verb"=>"update_systems"}], "resource_type"=>{"created_at"=>"2013-11-07T16:36:56Z", "id"=>5, "name"=>"system_groups", "updated_at"=>"2013-11-07T16:36:56Z"}}
+
+        @existing[@roles[details[:role]]] ||= {}
+        @permission_api.index({'role_id' => @roles[details[:role]]}).each do |permission|
+            @existing[@roles[details[:role]]][permission['name']] = permission['id']
+        end
+
+        puts @existing
+        return 1
+
+        details[:count].times do |number|
+          name = namify(details[:name_format], number)
+          if !@existing.include? name
+            @permission_api.create({
+                               :permission => {
+                                 :name => name,
+                                 :email => details[:email],
+                                 :password => 'admin'
+                               }
+                             }, {'Accept' => 'version=2,application/json'})
+          else
+            puts "Skip existing permission '#{name}'"
           end
         end
       end
 
-      splits.each do |thread|
-        thread.join
+      def parse_permission_csv(line)
+        keys = [:name_format, :count, :role, :description]
+        details = CSV.parse(line).map { |a| Hash[keys.zip(a)] }[0]
+
+        details[:count] = details[:count].to_i
+
+        details
       end
-
-      HammerCLI::EX_OK
-    end
-
-    def create_permissions_from_csv(line)
-      details = parse_permission_csv(line)
-
-      puts @permission_api.index({'role_id' => @roles['User System Group']})
-      # {"all_tags"=>false, "all_verbs"=>false, "created_at"=>"2013-11-11T02:31:23Z", "description"=>"and it's description!", "id"=>12, "name"=>"Accounting System Group Modify Systems", "organization_id"=>2, "resource_type_id"=>5, "role_id"=>124, "updated_at"=>"2013-11-11T02:31:23Z", "tags"=>[{"created_at"=>"2013-11-11T02:31:23Z", "formatted"=>{"name"=>6, "display_name"=>"Accounting"}, "id"=>2, "permission_id"=>12, "tag_id"=>6, "updated_at"=>"2013-11-11T02:31:23Z"}], "verbs"=>[{"created_at"=>"2013-11-07T19:44:45Z", "id"=>7, "updated_at"=>"2013-11-07T19:44:45Z", "verb"=>"update_systems"}], "resource_type"=>{"created_at"=>"2013-11-07T16:36:56Z", "id"=>5, "name"=>"system_groups", "updated_at"=>"2013-11-07T16:36:56Z"}}
-
-      @existing[@roles[details[:role]]] ||= {}
-      @permission_api.index({'role_id' => @roles[details[:role]]}).each do |permission|
-          @existing[@roles[details[:role]]][permission['name']] = permission['id']
-      end
-
-      puts @existing
-      return 1
-
-      details[:count].times do |number|
-        name = namify(details[:name_format], number)
-        if !@existing.include? name
-          @permission_api.create({
-                             :permission => {
-                               :name => name,
-                               :email => details[:email],
-                               :password => 'admin'
-                             }
-                           }, {'Accept' => 'version=2,application/json'})
-        else
-          puts "Skip existing permission '#{name}'"
-        end
-      end
-    end
-
-    def parse_permission_csv(line)
-      keys = [:name_format, :count, :role, :description]
-      details = CSV.parse(line).map { |a| Hash[keys.zip(a)] }[0]
-
-      details[:count] = details[:count].to_i
-
-      details
     end
   end
-
-  HammerCLICsv::CsvCommand.subcommand("permissions",
-                                      "import or export permissions",
-                                      HammerCLICsv::PermissionsCommand)
 end

--- a/lib/hammer_cli_csv/products.rb
+++ b/lib/hammer_cli_csv/products.rb
@@ -26,190 +26,191 @@ require 'csv'
 require 'uri'
 
 module HammerCLICsv
-  class ProductsCommand < BaseCommand
-    LABEL = 'Label'
-    ORGANIZATION = 'Organization'
-    REPOSITORY = 'Repository'
-    REPOSITORY_TYPE = 'Repository Type'
-    REPOSITORY_URL = 'Repository Url'
-    DESCRIPTION = 'Description'
+  class CsvCommand
+    class ProductsCommand < BaseCommand
+      command_name 'products'
+      desc         'import or export products'
 
-    def export
-      CSV.open(option_csv_file || '/dev/stdout', 'wb', {:force_quotes => false}) do |csv|
-        csv << [NAME, COUNT, LABEL, ORGANIZATION, REPOSITORY, REPOSITORY_TYPE, REPOSITORY_URL]
-        @api.resource(:organizations).call(:index, {:per_page => 999999})['results'].each do |organization|
+      LABEL = 'Label'
+      ORGANIZATION = 'Organization'
+      REPOSITORY = 'Repository'
+      REPOSITORY_TYPE = 'Repository Type'
+      REPOSITORY_URL = 'Repository Url'
+      DESCRIPTION = 'Description'
+
+      def export
+        CSV.open(option_csv_file || '/dev/stdout', 'wb', {:force_quotes => false}) do |csv|
+          csv << [NAME, COUNT, LABEL, ORGANIZATION, REPOSITORY, REPOSITORY_TYPE, REPOSITORY_URL]
+          @api.resource(:organizations).call(:index, {:per_page => 999999})['results'].each do |organization|
+            @api.resource(:products).call(:index, {
+                                            'per_page' => 999999,
+                                            'enabled' => true,
+                                            'organization_id' => katello_organization(:name => organization['name'])
+                                          })['results'].each do |product|
+              # product = @api.resource(:products).call(:show, {
+              #                                           'id' => product['id'],
+              #                                           'fields' => 'full'
+              #                                         })
+              product['library_repositories'].each do |repository|
+                if repository['sync_state'] != 'not_synced'
+                  repository_type = "#{repository['product_type'] == 'custom' ? 'Custom' : 'Red Hat'} #{repository['content_type'].capitalize}"
+                  csv << [namify(product['name'], 1), 1, product['label'], organization['name'], repository['name'],
+                          repository_type, repository['feed']]
+                  #puts "  HTTPS:                     #{repository['unprotected'] ? 'No' : 'Yes'}"
+                end
+              end
+
+            end
+          end
+        end
+      end
+
+      def import
+        @existing_products = {}
+        @existing_repositories = {}
+
+        thread_import do |line|
+          create_products_from_csv(line)
+        end
+      end
+
+      def create_products_from_csv(line)
+        if !@existing_products[line[ORGANIZATION]]
+          @existing_products[line[ORGANIZATION]] = {}
           @api.resource(:products).call(:index, {
-                                          'per_page' => 999999,
-                                          'enabled' => true,
-                                          'organization_id' => katello_organization(:name => organization['name'])
-                                        })['results'].each do |product|
-            # product = @api.resource(:products).call(:show, {
-            #                                           'id' => product['id'],
-            #                                           'fields' => 'full'
-            #                                         })
-            product['library_repositories'].each do |repository|
-              if repository['sync_state'] != 'not_synced'
-                repository_type = "#{repository['product_type'] == 'custom' ? 'Custom' : 'Red Hat'} #{repository['content_type'].capitalize}"
-                csv << [namify(product['name'], 1), 1, product['label'], organization['name'], repository['name'],
-                        repository_type, repository['feed']]
-                #puts "  HTTPS:                     #{repository['unprotected'] ? 'No' : 'Yes'}"
+                                 'organization_id' => katello_organization(:name => line[ORGANIZATION]),
+                                 'page_size' => 999999,
+                                 'paged' => true
+                               })['results'].each do |product|
+            @existing_products[line[ORGANIZATION]][product['name']] = product['id'] if product
+
+            if product
+              @api.resource(:repositories).call(:index, {
+                                        'organization_id' => katello_organization(:name => line[ORGANIZATION]),
+                                        'product_id' => product['id'],
+                                        'enabled' => true,
+                                        'library' => true,
+                                        'page_size' => 999999, 'paged' => true
+                                      })['results'].each do |repository|
+                @existing_repositories[line[ORGANIZATION] + product['name']] ||= {}
+                @existing_repositories[line[ORGANIZATION] + product['name']][repository['label']] = repository['id']
               end
             end
-
           end
         end
-      end
-    end
 
-    def import
-      @existing_products = {}
-      @existing_repositories = {}
-
-      thread_import do |line|
-        create_products_from_csv(line)
-      end
-    end
-
-    def create_products_from_csv(line)
-      if !@existing_products[line[ORGANIZATION]]
-        @existing_products[line[ORGANIZATION]] = {}
-        @api.resource(:products).call(:index, {
-                               'organization_id' => katello_organization(:name => line[ORGANIZATION]),
-                               'page_size' => 999999,
-                               'paged' => true
-                             })['results'].each do |product|
-          @existing_products[line[ORGANIZATION]][product['name']] = product['id'] if product
-
-          if product
-            @api.resource(:repositories).call(:index, {
-                                      'organization_id' => katello_organization(:name => line[ORGANIZATION]),
-                                      'product_id' => product['id'],
-                                      'enabled' => true,
-                                      'library' => true,
-                                      'page_size' => 999999, 'paged' => true
-                                    })['results'].each do |repository|
-              @existing_repositories[line[ORGANIZATION] + product['name']] ||= {}
-              @existing_repositories[line[ORGANIZATION] + product['name']][repository['label']] = repository['id']
+        # Only creating products, not updating
+        line[COUNT].to_i.times do |number|
+          name = namify(line[NAME], number)
+          puts @existing_products
+          product_id = @existing_products[line[ORGANIZATION]][name]
+          if !product_id
+            print "Creating product '#{name}'..." if option_verbose?
+            if line[REPOSITORY_TYPE] =~ /Red Hat/
+              raise "Red Hat product '#{name}' does not exist in '#{line[ORGANIZATION]}'"
             end
+
+            product_id = @api.resource(:products).call(:create, {
+                                                 'organization_id' => katello_organization(:name => line[ORGANIZATION]),
+                                                 'name' => name
+                                               })['id']
+            @existing_products[line[ORGANIZATION]][name] = product_id
+          else
+            # Nothing to update for products
+            print "Updating product '#{name}'..." if option_verbose?
           end
-        end
-      end
+          @existing_repositories[line[ORGANIZATION] + name] = {}
+          print "done\n" if option_verbose?
 
-      # Only creating products, not updating
-      line[COUNT].to_i.times do |number|
-        name = namify(line[NAME], number)
-        puts @existing_products
-        product_id = @existing_products[line[ORGANIZATION]][name]
-        if !product_id
-          print "Creating product '#{name}'..." if option_verbose?
-          if line[REPOSITORY_TYPE] =~ /Red Hat/
-            raise "Red Hat product '#{name}' does not exist in '#{line[ORGANIZATION]}'"
-          end
+          repository_name = namify(line[REPOSITORY], number)
 
-          product_id = @api.resource(:products).call(:create, {
-                                               'organization_id' => katello_organization(:name => line[ORGANIZATION]),
-                                               'name' => name
-                                             })['id']
-          @existing_products[line[ORGANIZATION]][name] = product_id
-        else
-          # Nothing to update for products
-          print "Updating product '#{name}'..." if option_verbose?
-        end
-        @existing_repositories[line[ORGANIZATION] + name] = {}
-        print "done\n" if option_verbose?
-
-        repository_name = namify(line[REPOSITORY], number)
-
-        # Hash the existing repositories for the product
-        if !@existing_repositories[line[ORGANIZATION] + name][repository_name]
-          @api.resource(:repositories).call(:index, {
-                                              'organization_id' => katello_organization(:name => line[ORGANIZATION]),
-                                              'library' => true,
-                                              'all' => false,
-                                              'product_id' => product_id
-                                            })['results'].each do |repository|
-            @existing_repositories[line[ORGANIZATION] + name][repository['name']] = repository
-          end
-        end
-
-        if !@existing_repositories[line[ORGANIZATION] + name][repository_name]
-          print "Creating repository '#{repository_name}' in product '#{name}'..." if option_verbose?
-          if line[REPOSITORY_TYPE] =~ /Red Hat/
-            # TMP
-            puts "TMP"
+          # Hash the existing repositories for the product
+          if !@existing_repositories[line[ORGANIZATION] + name][repository_name]
             @api.resource(:repositories).call(:index, {
                                                 'organization_id' => katello_organization(:name => line[ORGANIZATION]),
                                                 'library' => true,
-                                                'all' => true,
+                                                'all' => false,
                                                 'product_id' => product_id
                                               })['results'].each do |repository|
-              puts repository if repository['name'] == repository_name
+              @existing_repositories[line[ORGANIZATION] + name][repository['name']] = repository
             end
-            puts "END TMP"
-            #repository_id = redhat_create_repository(product_id, repository_name)
-
-          else
-            repository_id = @api.resource(:repositories).call(:create, {
-                                       'organization_id' => katello_organization(:name => line[ORGANIZATION]),
-                                       'name' => repository_name,
-                                       'label' => labelize(repository_name),
-                                       'product_id' => product_id,
-                                       'url' => line[REPOSITORY_URL],
-                                       'content_type' => content_type(line[REPOSITORY_TYPE])
-                                     })['id']
           end
-          @existing_repositories[line[ORGANIZATION] + name][line[LABEL]] = repository_id
 
-          puts "TODO: skipping sync"
-          # task_id = @api.resource(:repositories).call(:sync, {
-          #                                               'organization_id' => katello_organization(:name => line[ORGANIZATION]),
-          #                                               'id' => repository_id
-          #                                             })['id']
-          # TODO: wait for sync task
-          print "done\n" if option_verbose?
+          if !@existing_repositories[line[ORGANIZATION] + name][repository_name]
+            print "Creating repository '#{repository_name}' in product '#{name}'..." if option_verbose?
+            if line[REPOSITORY_TYPE] =~ /Red Hat/
+              # TMP
+              puts "TMP"
+              @api.resource(:repositories).call(:index, {
+                                                  'organization_id' => katello_organization(:name => line[ORGANIZATION]),
+                                                  'library' => true,
+                                                  'all' => true,
+                                                  'product_id' => product_id
+                                                })['results'].each do |repository|
+                puts repository if repository['name'] == repository_name
+              end
+              puts "END TMP"
+              #repository_id = redhat_create_repository(product_id, repository_name)
+
+            else
+              repository_id = @api.resource(:repositories).call(:create, {
+                                         'organization_id' => katello_organization(:name => line[ORGANIZATION]),
+                                         'name' => repository_name,
+                                         'label' => labelize(repository_name),
+                                         'product_id' => product_id,
+                                         'url' => line[REPOSITORY_URL],
+                                         'content_type' => content_type(line[REPOSITORY_TYPE])
+                                       })['id']
+            end
+            @existing_repositories[line[ORGANIZATION] + name][line[LABEL]] = repository_id
+
+            puts "TODO: skipping sync"
+            # task_id = @api.resource(:repositories).call(:sync, {
+            #                                               'organization_id' => katello_organization(:name => line[ORGANIZATION]),
+            #                                               'id' => repository_id
+            #                                             })['id']
+            # TODO: wait for sync task
+            print "done\n" if option_verbose?
+          end
         end
+
+      rescue RuntimeError => e
+        raise "#{e}\n       #{line}"
       end
 
-    rescue RuntimeError => e
-      raise "#{e}\n       #{line}"
-    end
+      private
 
-    private
-
-    def redhat_create_repository(product_id, repository_name)
-      @api.resource(:repository_sets).call(:index, {
-                                             'product_id' => product_id
-                                           })['results'].each do |repository|
-        puts repository
-        puts @api.resource(:repository_sets).call(:show, {
-                                                    'product_id' => product_id,
-                                                    'id' => repository['id']})
-        return
-        if repository['name'] == repository_name
+      def redhat_create_repository(product_id, repository_name)
+        @api.resource(:repository_sets).call(:index, {
+                                               'product_id' => product_id
+                                             })['results'].each do |repository|
           puts repository
-          @api.resource(:repository_sets).call(:enable, {
-                                                 'product_id' => product_id,
-                                                 'repository_id' => repository['id']
-                                               })
+          puts @api.resource(:repository_sets).call(:show, {
+                                                      'product_id' => product_id,
+                                                      'id' => repository['id']})
           return
+          if repository['name'] == repository_name
+            puts repository
+            @api.resource(:repository_sets).call(:enable, {
+                                                   'product_id' => product_id,
+                                                   'repository_id' => repository['id']
+                                                 })
+            return
+          end
+          raise "Repository '#{repository_name}' does not exist"
         end
-        raise "Repository '#{repository_name}' does not exist"
       end
-    end
 
-    def content_type(repository_type)
-      case repository_type
-        when /Yum/
-          'yum'
-        when /Puppet/
-          'puppet'
-        else
-        raise "Unrecognized repository type '#{repository_type}'"
+      def content_type(repository_type)
+        case repository_type
+          when /Yum/
+            'yum'
+          when /Puppet/
+            'puppet'
+          else
+          raise "Unrecognized repository type '#{repository_type}'"
+        end
       end
     end
   end
-
-  HammerCLICsv::CsvCommand.subcommand('products',
-                                      'import or export products',
-                                      HammerCLICsv::ProductsCommand)
 end

--- a/lib/hammer_cli_csv/puppet_facts.rb
+++ b/lib/hammer_cli_csv/puppet_facts.rb
@@ -28,69 +28,70 @@ require 'json'
 require 'csv'
 
 module HammerCLICsv
-  class PuppetFactsCommand < BaseCommand
+  class CsvCommand
+    class PuppetFactsCommand < BaseCommand
 
-    def export
-      CSV.open(option_csv_file || '/dev/stdout', 'wb', {:force_quotes => true}) do |csv|
-        headers = [NAME, COUNT]
-        # Extracted facts are always based upon the first host found, otherwise this would be an intensive
-        # method to gather all the possible column names
-        host = @api.resource(:hosts).call(:index, {:per_page => 1})['results'][0]
-        headers += @api.resource(:puppetfactss).call(:index, {'host_id' => host['name'], 'per_page' => 999999})['results'][host['name']].keys
-        csv << headers
+      command_name "puppet-facts"
+      desc         "import or export puppet facts"
 
-        @api.resource(:hosts).call(:index, {:per_page => 999999})['results'].each do |host|
-          line = [host['name'], 1]
-          facts = @api.resource(:puppetfactss).call(:index, {'host_id' => host['name'], 'per_page' => 999999})[host['name']]
-          facts ||= {}
-          headers[2..-1].each do |fact_name|
-            line << facts[fact_name] || ''
-          end
-          csv << line
-        end
-      end
-    end
+      def export
+        CSV.open(option_csv_file || '/dev/stdout', 'wb', {:force_quotes => true}) do |csv|
+          headers = [NAME, COUNT]
+          # Extracted facts are always based upon the first host found, otherwise this would be an intensive
+          # method to gather all the possible column names
+          host = @api.resource(:hosts).call(:index, {:per_page => 1})['results'][0]
+          headers += @api.resource(:puppetfactss).call(:index, {'host_id' => host['name'], 'per_page' => 999999})['results'][host['name']].keys
+          csv << headers
 
-    def import
-      @headers = nil
-
-      thread_import(true) do |line|
-        create_puppetfacts_from_csv(line)
-      end
-    end
-
-    def create_puppetfacts_from_csv(line)
-      if @headers.nil?
-        @headers = line
-        return
-      end
-
-      line[COUNT].to_i.times do |number|
-        name = namify(line[NAME], number)
-        print "Updating puppetfacts '#{name}'..." if option_verbose?
-        facts = line.to_hash
-        facts.delete(NAME)
-        facts.delete(COUNT)
-
-        # Namify the values if the host name was namified
-        if name != line[NAME]
-          facts.each do |fact, value|
-            facts[fact] = namify(value, number) unless value.nil? || value.empty?
+          @api.resource(:hosts).call(:index, {:per_page => 999999})['results'].each do |host|
+            line = [host['name'], 1]
+            facts = @api.resource(:puppetfactss).call(:index, {'host_id' => host['name'], 'per_page' => 999999})[host['name']]
+            facts ||= {}
+            headers[2..-1].each do |fact_name|
+              line << facts[fact_name] || ''
+            end
+            csv << line
           end
         end
-
-        @api.resource(:hosts).call(:facts, {
-                            'name' => name,
-                            'facts' => facts
-                          })
-        print "done\n" if option_verbose?
       end
-    rescue RuntimeError => e
-      raise "#{e}\n       #{line}"
+
+      def import
+        @headers = nil
+
+        thread_import(true) do |line|
+          create_puppetfacts_from_csv(line)
+        end
+      end
+
+      def create_puppetfacts_from_csv(line)
+        if @headers.nil?
+          @headers = line
+          return
+        end
+
+        line[COUNT].to_i.times do |number|
+          name = namify(line[NAME], number)
+          print "Updating puppetfacts '#{name}'..." if option_verbose?
+          facts = line.to_hash
+          facts.delete(NAME)
+          facts.delete(COUNT)
+
+          # Namify the values if the host name was namified
+          if name != line[NAME]
+            facts.each do |fact, value|
+              facts[fact] = namify(value, number) unless value.nil? || value.empty?
+            end
+          end
+
+          @api.resource(:hosts).call(:facts, {
+                              'name' => name,
+                              'facts' => facts
+                            })
+          print "done\n" if option_verbose?
+        end
+      rescue RuntimeError => e
+        raise "#{e}\n       #{line}"
+      end
     end
   end
-
-  HammerCLICsv::CsvCommand.subcommand("puppet-facts",
-                                      "import or export puppet facts",
-                                      HammerCLICsv::PuppetFactsCommand)
 end

--- a/lib/hammer_cli_csv/puppet_reports.rb
+++ b/lib/hammer_cli_csv/puppet_reports.rb
@@ -32,197 +32,198 @@ require 'csv'
 require 'uri'
 
 module HammerCLICsv
-  class PuppetReportsCommand < BaseCommand
+  class CsvCommand
+    class PuppetReportsCommand < BaseCommand
 
-    ORGANIZATION = 'Organization'
-    ENVIRONMENT = 'Environment'
-    CONTENTVIEW = 'Content View'
-    SYSTEMGROUPS = 'System Groups'
-    VIRTUAL = 'Virtual'
-    HOST = 'Host'
-    OPERATINGSYSTEM = 'OS'
-    ARCHITECTURE = 'Arch'
-    SOCKETS = 'Sockets'
-    RAM = 'RAM'
-    CORES = 'Cores'
-    SLA = 'SLA'
-    PRODUCTS = 'Products'
-    SUBSCRIPTIONS = 'Subscriptions'
+      command_name "puppet-reports"
+      desc         "import or export puppet reports"
 
-    def export
-      CSV.open(option_csv_file || '/dev/stdout', 'wb', {:force_quotes => false}) do |csv|
-        csv << [NAME, COUNT, ORGANIZATION, ENVIRONMENT, CONTENTVIEW, SYSTEMGROUPS, VIRTUAL, HOST,
-               OPERATINGSYSTEM, ARCHITECTURE, SOCKETS, RAM, CORES, SLA, PRODUCTS, SUBSCRIPTIONS]
-        @api.resource(:organizations).call(:index, {:per_page => 999999})['results'].each do |organization|
-          @api.resource(:systems).call(:index, {
-                                'per_page' => 999999,
-                                'organization_id' => organization['label']
-                               })['results'].each do |system|
-            system = @api.resource(:systems).call(:show, {
-                                          'id' => system['uuid'],
-                                          'fields' => 'full'
-                                        })
+      ORGANIZATION = 'Organization'
+      ENVIRONMENT = 'Environment'
+      CONTENTVIEW = 'Content View'
+      SYSTEMGROUPS = 'System Groups'
+      VIRTUAL = 'Virtual'
+      HOST = 'Host'
+      OPERATINGSYSTEM = 'OS'
+      ARCHITECTURE = 'Arch'
+      SOCKETS = 'Sockets'
+      RAM = 'RAM'
+      CORES = 'Cores'
+      SLA = 'SLA'
+      PRODUCTS = 'Products'
+      SUBSCRIPTIONS = 'Subscriptions'
 
-            name = system['name']
-            count = 1
-            organization_label = organization['label']
-            environment = system['environment']['label']
-            contentview = system['content_view']['name']
-            systemgroups = CSV.generate do |column|
-              column << system['systemGroups'].collect do |systemgroup|
-                systemgroup['name']
-              end
-            end.delete!("\n")
-            virtual = system['facts']['virt.is_guest'] == 'true' ? 'Yes' : 'No'
-            host = system['host']
-            operatingsystem = "#{system['facts']['distribution.name']} " if system['facts']['distribution.name']
-            operatingsystem += system['facts']['distribution.version'] if system['facts']['distribution.version']
-            architecture = system['facts']['uname.machine']
-            sockets = system['facts']['cpu.cpu_socket(s)']
-            ram = system['facts']['memory.memtotal']
-            cores = system['facts']['cpu.core(s)_per_socket']
-            sla = ""
-            products = CSV.generate do |column|
-              column << system['installedProducts'].collect do |product|
-                "#{product['productId']}|#{product['productName']}"
-              end
-            end.delete!("\n")
-            subscriptions = CSV.generate do |column|
-              column << @api.resource(:subscriptions).call(:index, {
-                                                    'system_id' => system['uuid']
-                                                  })['results'].collect do |subscription|
-                "#{subscription['product_id']}|#{subscription['product_name']}"
-              end
-            end.delete!("\n")
-            csv << [name, count, organization_label, environment, contentview, systemgroups, virtual, host,
-                    operatingsystem, architecture, sockets, ram, cores, sla, products, subscriptions]
+      def export
+        CSV.open(option_csv_file || '/dev/stdout', 'wb', {:force_quotes => false}) do |csv|
+          csv << [NAME, COUNT, ORGANIZATION, ENVIRONMENT, CONTENTVIEW, SYSTEMGROUPS, VIRTUAL, HOST,
+                 OPERATINGSYSTEM, ARCHITECTURE, SOCKETS, RAM, CORES, SLA, PRODUCTS, SUBSCRIPTIONS]
+          @api.resource(:organizations).call(:index, {:per_page => 999999})['results'].each do |organization|
+            @api.resource(:systems).call(:index, {
+                                  'per_page' => 999999,
+                                  'organization_id' => organization['label']
+                                 })['results'].each do |system|
+              system = @api.resource(:systems).call(:show, {
+                                            'id' => system['uuid'],
+                                            'fields' => 'full'
+                                          })
+
+              name = system['name']
+              count = 1
+              organization_label = organization['label']
+              environment = system['environment']['label']
+              contentview = system['content_view']['name']
+              systemgroups = CSV.generate do |column|
+                column << system['systemGroups'].collect do |systemgroup|
+                  systemgroup['name']
+                end
+              end.delete!("\n")
+              virtual = system['facts']['virt.is_guest'] == 'true' ? 'Yes' : 'No'
+              host = system['host']
+              operatingsystem = "#{system['facts']['distribution.name']} " if system['facts']['distribution.name']
+              operatingsystem += system['facts']['distribution.version'] if system['facts']['distribution.version']
+              architecture = system['facts']['uname.machine']
+              sockets = system['facts']['cpu.cpu_socket(s)']
+              ram = system['facts']['memory.memtotal']
+              cores = system['facts']['cpu.core(s)_per_socket']
+              sla = ""
+              products = CSV.generate do |column|
+                column << system['installedProducts'].collect do |product|
+                  "#{product['productId']}|#{product['productName']}"
+                end
+              end.delete!("\n")
+              subscriptions = CSV.generate do |column|
+                column << @api.resource(:subscriptions).call(:index, {
+                                                      'system_id' => system['uuid']
+                                                    })['results'].collect do |subscription|
+                  "#{subscription['product_id']}|#{subscription['product_name']}"
+                end
+              end.delete!("\n")
+              csv << [name, count, organization_label, environment, contentview, systemgroups, virtual, host,
+                      operatingsystem, architecture, sockets, ram, cores, sla, products, subscriptions]
+            end
           end
         end
       end
-    end
 
-    def import
-      @existing = {}
-      @host_guests = {}
+      def import
+        @existing = {}
+        @host_guests = {}
 
-      thread_import do |line|
-        create_systems_from_csv(line)
-      end
-
-      print "Updating host and guest associations..." if option_verbose?
-      @host_guests.each do |host_id, guest_ids|
-        @api.resource(:systems).call(:update, {
-                               'id' => host_id,
-                               'guest_ids' => guest_ids
-                             })
-      end
-      puts "done" if option_verbose?
-    end
-
-    def create_systems_from_csv(line)
-      if !@existing[line[ORGANIZATION]]
-        @existing[line[ORGANIZATION]] = {}
-        @api.resource(:systems).call(:index, {'organization_id' => line[ORGANIZATION], 'page_size' => 999999})['results'].each do |system|
-          @existing[line[ORGANIZATION]][system['name']] = system['uuid'] if system
-        end
-      end
-
-      line[COUNT].to_i.times do |number|
-        name = namify(line[NAME], number)
-
-        # TODO w/ @daviddavis p-r
-        #subscriptions(line).each do |subscription|
-        #  katello_subscription(line[ORGANIZATION], :name => subscription[:number])
-        #end
-
-        if !@existing[line[ORGANIZATION]].include? name
-          print "Creating system '#{name}'..." if option_verbose?
-          system_id = @api.resource(:systems).call(:create, {
-                                 'name' => name,
-                                 'organization_id' => line[ORGANIZATION],
-                                 'environment_id' => katello_environment(line[ORGANIZATION], :name => line[ENVIRONMENT]),
-                                 'content_view_id' => katello_contentview(line[ORGANIZATION], :name => line[CONTENTVIEW]),
-                                 'facts' => facts(line),
-                                 'installed_products' => products(line),
-                                 'type' => 'system'
-                               })['uuid']
-          @existing[line[ORGANIZATION]][name] = system_id
-        else
-          print "Updating system '#{name}'..." if option_verbose?
-          puts line
-          system_id = @api.resource(:systems).call(:update, {
-                                 'id' => @existing[line[ORGANIZATION]][name],
-                                 'name' => name,
-                                 'environment_id' => katello_environment(line[ORGANIZATION], :name => line[ENVIRONMENT]),
-                                 'content_view_id' => katello_contentview(line[ORGANIZATION], :name => line[CONTENTVIEW]),
-                                 'facts' => facts(line),
-                                 'installed_products' => products(line)
-                               })['uuid']
+        thread_import do |line|
+          create_systems_from_csv(line)
         end
 
-        if line[VIRTUAL] == 'Yes' && line[HOST]
-          raise "Host system '#{line[HOST]}' not found" if !@existing[line[ORGANIZATION]][line[HOST]]
-          @host_guests[@existing[line[ORGANIZATION]][line[HOST]]] ||= []
-          @host_guests[@existing[line[ORGANIZATION]][line[HOST]]] << system_id
+        print "Updating host and guest associations..." if option_verbose?
+        @host_guests.each do |host_id, guest_ids|
+          @api.resource(:systems).call(:update, {
+                                 'id' => host_id,
+                                 'guest_ids' => guest_ids
+                               })
         end
-
-        set_system_groups(system_id, line)
-
         puts "done" if option_verbose?
       end
-    rescue RuntimeError => e
-      raise "#{e}\n       #{line}"
-    end
 
-    private
+      def create_systems_from_csv(line)
+        if !@existing[line[ORGANIZATION]]
+          @existing[line[ORGANIZATION]] = {}
+          @api.resource(:systems).call(:index, {'organization_id' => line[ORGANIZATION], 'page_size' => 999999})['results'].each do |system|
+            @existing[line[ORGANIZATION]][system['name']] = system['uuid'] if system
+          end
+        end
 
-    def facts(line)
-      facts = {}
-      facts['cpu.core(s)_per_socket'] = line[CORES]
-      facts['cpu.cpu_socket(s)'] = line[SOCKETS]
-      facts['memory.memtotal'] = line[RAM]
-      facts['uname.machine'] = line[ARCHITECTURE]
-      if line[OPERATINGSYSTEM].index(' ')
-        (facts['distribution.name'], facts['distribution.version']) = line[OPERATINGSYSTEM].split(' ')
-      else
-        (facts['distribution.name'], facts['distribution.version']) = ['RHEL', line[OPERATINGSYSTEM]]
+        line[COUNT].to_i.times do |number|
+          name = namify(line[NAME], number)
+
+          # TODO w/ @daviddavis p-r
+          #subscriptions(line).each do |subscription|
+          #  katello_subscription(line[ORGANIZATION], :name => subscription[:number])
+          #end
+
+          if !@existing[line[ORGANIZATION]].include? name
+            print "Creating system '#{name}'..." if option_verbose?
+            system_id = @api.resource(:systems).call(:create, {
+                                   'name' => name,
+                                   'organization_id' => line[ORGANIZATION],
+                                   'environment_id' => katello_environment(line[ORGANIZATION], :name => line[ENVIRONMENT]),
+                                   'content_view_id' => katello_contentview(line[ORGANIZATION], :name => line[CONTENTVIEW]),
+                                   'facts' => facts(line),
+                                   'installed_products' => products(line),
+                                   'type' => 'system'
+                                 })['uuid']
+            @existing[line[ORGANIZATION]][name] = system_id
+          else
+            print "Updating system '#{name}'..." if option_verbose?
+            puts line
+            system_id = @api.resource(:systems).call(:update, {
+                                   'id' => @existing[line[ORGANIZATION]][name],
+                                   'name' => name,
+                                   'environment_id' => katello_environment(line[ORGANIZATION], :name => line[ENVIRONMENT]),
+                                   'content_view_id' => katello_contentview(line[ORGANIZATION], :name => line[CONTENTVIEW]),
+                                   'facts' => facts(line),
+                                   'installed_products' => products(line)
+                                 })['uuid']
+          end
+
+          if line[VIRTUAL] == 'Yes' && line[HOST]
+            raise "Host system '#{line[HOST]}' not found" if !@existing[line[ORGANIZATION]][line[HOST]]
+            @host_guests[@existing[line[ORGANIZATION]][line[HOST]]] ||= []
+            @host_guests[@existing[line[ORGANIZATION]][line[HOST]]] << system_id
+          end
+
+          set_system_groups(system_id, line)
+
+          puts "done" if option_verbose?
+        end
+      rescue RuntimeError => e
+        raise "#{e}\n       #{line}"
       end
-      facts['virt.is_guest'] = line[VIRTUAL] == 'Yes' ? true : false
-      facts
-    end
 
-    def set_system_groups(system_id, line)
-      CSV.parse_line(line[SYSTEMGROUPS]).each do |systemgroup_name|
-        @api.resource(:systemgroups).call(:add_systems, {
-                                         'id' => katello_systemgroup(line[ORGANIZATION], :name => systemgroup_name),
-                                         'system_ids' => [system_id]
-                                       })
+      private
+
+      def facts(line)
+        facts = {}
+        facts['cpu.core(s)_per_socket'] = line[CORES]
+        facts['cpu.cpu_socket(s)'] = line[SOCKETS]
+        facts['memory.memtotal'] = line[RAM]
+        facts['uname.machine'] = line[ARCHITECTURE]
+        if line[OPERATINGSYSTEM].index(' ')
+          (facts['distribution.name'], facts['distribution.version']) = line[OPERATINGSYSTEM].split(' ')
+        else
+          (facts['distribution.name'], facts['distribution.version']) = ['RHEL', line[OPERATINGSYSTEM]]
+        end
+        facts['virt.is_guest'] = line[VIRTUAL] == 'Yes' ? true : false
+        facts
       end
-    end
 
-    def products(line)
-      products = CSV.parse_line(line[PRODUCTS]).collect do |product_details|
-        product = {}
-        # TODO: these get passed straight through to candlepin; probably would be better to process in server
-        #       to allow underscore product_id here
-        (product['productId'], product['productName']) = product_details.split('|')
-        product
+      def set_system_groups(system_id, line)
+        CSV.parse_line(line[SYSTEMGROUPS]).each do |systemgroup_name|
+          @api.resource(:systemgroups).call(:add_systems, {
+                                           'id' => katello_systemgroup(line[ORGANIZATION], :name => systemgroup_name),
+                                           'system_ids' => [system_id]
+                                         })
+        end
       end
-      products
-    end
 
-    def subscriptions(line)
-      subscriptions = CSV.parse_line(line[SUBSCRIPTIONS]).collect do |subscription_details|
-        subscription = {}
-        (subscription[:number], subscription[:name]) = subscription_details.split('|')
-        subscription
+      def products(line)
+        products = CSV.parse_line(line[PRODUCTS]).collect do |product_details|
+          product = {}
+          # TODO: these get passed straight through to candlepin; probably would be better to process in server
+          #       to allow underscore product_id here
+          (product['productId'], product['productName']) = product_details.split('|')
+          product
+        end
+        products
       end
-      subscriptions
-    end
 
+      def subscriptions(line)
+        subscriptions = CSV.parse_line(line[SUBSCRIPTIONS]).collect do |subscription_details|
+          subscription = {}
+          (subscription[:number], subscription[:name]) = subscription_details.split('|')
+          subscription
+        end
+        subscriptions
+      end
+
+    end
   end
-
-  HammerCLICsv::CsvCommand.subcommand("puppet-reports",
-                                      "import or export puppet reports",
-                                      HammerCLICsv::PuppetReportsCommand)
 end

--- a/lib/hammer_cli_csv/reports.rb
+++ b/lib/hammer_cli_csv/reports.rb
@@ -11,93 +11,94 @@
 
 
 module HammerCLICsv
-  class ReportsCommand < BaseCommand
+  class CsvCommand
+    class ReportsCommand < BaseCommand
 
-    TIME = 'Time'
-    APPLIED = 'Applied'
-    RESTARTED = 'Restarted'
-    FAILED = 'Failed'
-    FAILED_RESTARTS = 'Failed Restarts'
-    SKIPPED = 'Skipped'
-    PENDING = 'Pending'
-    METRICS = 'Metrics'
+      command_name "reports"
+      desc         "import or export reports"
 
-    def export
-      CSV.open(option_csv_file || '/dev/stdout', 'wb', {:force_quotes => false}) do |csv|
-        csv << [NAME, COUNT]
+      TIME = 'Time'
+      APPLIED = 'Applied'
+      RESTARTED = 'Restarted'
+      FAILED = 'Failed'
+      FAILED_RESTARTS = 'Failed Restarts'
+      SKIPPED = 'Skipped'
+      PENDING = 'Pending'
+      METRICS = 'Metrics'
+
+      def export
+        CSV.open(option_csv_file || '/dev/stdout', 'wb', {:force_quotes => false}) do |csv|
+          csv << [NAME, COUNT]
+          @api.resource(:reports).call(:index, {'per_page' => 999999})['results'].each do |report|
+            csv << [report['host_name'], 1, report['metrics'].to_json]
+          end
+        end
+
+        HammerCLI::EX_OK
+      end
+
+      def import
+        @existing_reports = {}
         @api.resource(:reports).call(:index, {'per_page' => 999999})['results'].each do |report|
-          csv << [report['host_name'], 1, report['metrics'].to_json]
+          @existing_reports[report['name']] = report['id']
+        end
+
+        thread_import do |line|
+          create_reports_from_csv(line)
         end
       end
 
-      HammerCLI::EX_OK
-    end
+      def create_reports_from_csv(line)
+        line[COUNT].to_i.times do |number|
+          name = namify(line[NAME], number)
 
-    def import
-      @existing_reports = {}
-      @api.resource(:reports).call(:index, {'per_page' => 999999})['results'].each do |report|
-        @existing_reports[report['name']] = report['id']
-      end
-
-      thread_import do |line|
-        create_reports_from_csv(line)
-      end
-    end
-
-    def create_reports_from_csv(line)
-      line[COUNT].to_i.times do |number|
-        name = namify(line[NAME], number)
-
-        if !@existing_reports[name]
-          print "Creating report '#{name}'..." if option_verbose?
-          report = @api.resource(:reports).call(:create, {
-                                          'host' => name,
-                                          'reported_at' => line[TIME],
-                                          'status' => {
-                                            'applied' => line[APPLIED],
-                                            'restarted' => line[RESTARTED],
-                                            'failed' => line[FAILED],
-                                            'failed_restarts' => line[FAILED_RESTARTS],
-                                            'skipped' => line[SKIPPED],
-                                            'pending' => line[PENDING]
-                                          },
-                                          'metrics' => JSON.parse(line[METRICS]),
-                                          'logs' => []
-                                        })
+          if !@existing_reports[name]
+            print "Creating report '#{name}'..." if option_verbose?
+            report = @api.resource(:reports).call(:create, {
+                                            'host' => name,
+                                            'reported_at' => line[TIME],
+                                            'status' => {
+                                              'applied' => line[APPLIED],
+                                              'restarted' => line[RESTARTED],
+                                              'failed' => line[FAILED],
+                                              'failed_restarts' => line[FAILED_RESTARTS],
+                                              'skipped' => line[SKIPPED],
+                                              'pending' => line[PENDING]
+                                            },
+                                            'metrics' => JSON.parse(line[METRICS]),
+                                            'logs' => []
+                                          })
 =begin
-                                          'metrics' => {
-                                            'time' => {
-                                              'config_retrieval' => line[CONFIG_RETRIEVAL]
+                                            'metrics' => {
+                                              'time' => {
+                                                'config_retrieval' => line[CONFIG_RETRIEVAL]
+                                              },
+                                              'resources' => {
+                                                'applied' => 0,
+                                                'failed' => 0,
+                                                'failed_restarts' => 0,
+                                                'out_of_sync' => 0,
+                                                'restarted' => 0,
+                                                'scheduled' => 1368,
+                                                'skipped' => 1,
+                                                'total' => 1450
+                                              },
+                                              'changes' => {
+                                                'total' => 0
+                                              }
                                             },
-                                            'resources' => {
-                                              'applied' => 0,
-                                              'failed' => 0,
-                                              'failed_restarts' => 0,
-                                              'out_of_sync' => 0,
-                                              'restarted' => 0,
-                                              'scheduled' => 1368,
-                                              'skipped' => 1,
-                                              'total' => 1450
-                                            },
-                                            'changes' => {
-                                              'total' => 0
-                                            }
-                                          },
 =end
-          @existing_reports[name] = report['id']
-        else
-          print "Updating report '#{name}'..." if option_verbose?
-          @api.resource(:reports).call(:update, {
-                                 'id' => @existing_reports[name]
-                               })
-        end
+            @existing_reports[name] = report['id']
+          else
+            print "Updating report '#{name}'..." if option_verbose?
+            @api.resource(:reports).call(:update, {
+                                   'id' => @existing_reports[name]
+                                 })
+          end
 
-        puts "done" if option_verbose?
+          puts "done" if option_verbose?
+        end
       end
     end
   end
-
-  HammerCLICsv::CsvCommand.subcommand("reports",
-                                      "import or export reports",
-                                      HammerCLICsv::ReportsCommand)
 end

--- a/lib/hammer_cli_csv/roles.rb
+++ b/lib/hammer_cli_csv/roles.rb
@@ -27,118 +27,119 @@ require 'json'
 require 'csv'
 
 module HammerCLICsv
-  class RolesCommand < BaseCommand
+  class CsvCommand
+    class RolesCommand < BaseCommand
 
-    ROLE = "Role"
-    FILTER = "Filter"
-    PERMISSIONS = "Permissions"
-    ORGANIZATIONS = "Organizations"
-    LOCATIONS = "Locations"
+      command_name "roles"
+      desc         "import or export roles"
 
-    def export
-      CSV.open(option_csv_file || '/dev/stdout', 'wb', {:force_quotes => false}) do |csv|
-        csv << [NAME, COUNT, FILTER, PERMISSIONS, ORGANIZATIONS, LOCATIONS]
-        @api.resource(:roles).call(:index, {'per_page' => 999999})['results'].each do |role|
-          @api.resource(:filters).call(:index, {
-                                'per_page' => 999999,
-                                'search' => "role=\"#{role['name']}\""
-                              })['results'].each do |filter|
-            if filter['search'] && filter['search'] != ''
-              permissions = CSV.generate do |column|
-                column << filter['permissions'].collect do |permission|
-                  permission['name']
-                end
-              end.delete!("\n")
-              organizations = CSV.generate do |column|
-                column << filter['organizations'].collect do |organization|
-                  organization['name']
-                end
-              end.delete!("\n")
-              locations = CSV.generate do |column|
-                column << filter['locations'].collect do |location|
-                  location['name']
-                end
-              end.delete!("\n")
-              csv << [role['name'], 1, filter['search'], permissions, organizations, locations]
+      ROLE = "Role"
+      FILTER = "Filter"
+      PERMISSIONS = "Permissions"
+      ORGANIZATIONS = "Organizations"
+      LOCATIONS = "Locations"
+
+      def export
+        CSV.open(option_csv_file || '/dev/stdout', 'wb', {:force_quotes => false}) do |csv|
+          csv << [NAME, COUNT, FILTER, PERMISSIONS, ORGANIZATIONS, LOCATIONS]
+          @api.resource(:roles).call(:index, {'per_page' => 999999})['results'].each do |role|
+            @api.resource(:filters).call(:index, {
+                                  'per_page' => 999999,
+                                  'search' => "role=\"#{role['name']}\""
+                                })['results'].each do |filter|
+              if filter['search'] && filter['search'] != ''
+                permissions = CSV.generate do |column|
+                  column << filter['permissions'].collect do |permission|
+                    permission['name']
+                  end
+                end.delete!("\n")
+                organizations = CSV.generate do |column|
+                  column << filter['organizations'].collect do |organization|
+                    organization['name']
+                  end
+                end.delete!("\n")
+                locations = CSV.generate do |column|
+                  column << filter['locations'].collect do |location|
+                    location['name']
+                  end
+                end.delete!("\n")
+                csv << [role['name'], 1, filter['search'], permissions, organizations, locations]
+              end
             end
           end
         end
+
+        HammerCLI::EX_OK
       end
 
-      HammerCLI::EX_OK
-    end
-
-    def import
-      @existing_roles = {}
-      @api.resource(:roles).call(:index, {'per_page' => 999999})['results'].each do |role|
-        @existing_roles[role['name']] = role['id']
-      end
-
-      @existing_filters = {}
-      @api.resource(:filters).call(:index, {'per_page' => 999999})['results'].each do |role|
-        @existing_filters[role['name']] = role['id']
-      end
-
-      thread_import do |line|
-        create_roles_from_csv(line)
-      end
-    end
-
-    def create_roles_from_csv(line)
-      line[COUNT].to_i.times do |number|
-        name = namify(line[NAME], number)
-        filter = namify(line[FILTER], number) if line[FILTER]
-
-        if !@existing_roles[name]
-          print "Creating role '#{name}'..." if option_verbose?
-          role = @api.resource(:roles).call(:create, {
-                                      'name' => name
-                                    })
-          @existing_roles[name] = role['id']
-        else
-          print "Updating role '#{name}'..." if option_verbose?
-          @api.resource(:roles).call(:update, {
-                               'id' => @existing_roles[name]
-                             })
+      def import
+        @existing_roles = {}
+        @api.resource(:roles).call(:index, {'per_page' => 999999})['results'].each do |role|
+          @existing_roles[role['name']] = role['id']
         end
 
-        permissions = CSV.parse_line(line[PERMISSIONS], {:skip_blanks => true}).collect do |permission|
-          foreman_permission(:name => permission)
-        end if line[PERMISSIONS]
-        organizations = CSV.parse_line(line[ORGANIZATIONS], {:skip_blanks => true}).collect do |organization|
-          foreman_organization(:name => organization)
-        end if line[ORGANIZATIONS]
-        locations = CSV.parse_line(line[LOCATIONS], {:skip_blanks => true}).collect do |location|
-          foreman_location(:name => location)
-        end if line[LOCATIONS]
+        @existing_filters = {}
+        @api.resource(:filters).call(:index, {'per_page' => 999999})['results'].each do |role|
+          @existing_filters[role['name']] = role['id']
+        end
 
-        if filter
-          filter_id = foreman_filter(name, :name => filter)
-          if !filter_id
-            @api.resource(:filters).call(:create, {
-                                   'role_id' => @existing_roles[name],
-                                   'search' => filter,
-                                   'organization_ids' => organizations || [],
-                                   'location_ids' => locations || [],
-                                   'permission_ids' => permissions || []
-                                 })
+        thread_import do |line|
+          create_roles_from_csv(line)
+        end
+      end
+
+      def create_roles_from_csv(line)
+        line[COUNT].to_i.times do |number|
+          name = namify(line[NAME], number)
+          filter = namify(line[FILTER], number) if line[FILTER]
+
+          if !@existing_roles[name]
+            print "Creating role '#{name}'..." if option_verbose?
+            role = @api.resource(:roles).call(:create, {
+                                        'name' => name
+                                      })
+            @existing_roles[name] = role['id']
           else
-            @api.resource(:filters).call(:update, {
-                                   'id' => filter_id,
-                                   'search' => filter,
-                                   'organization_ids' => organizations || [],
-                                   'location_ids' => locations || [],
-                                   'permission_ids' => permissions || []
-                                 })
+            print "Updating role '#{name}'..." if option_verbose?
+            @api.resource(:roles).call(:update, {
+                                 'id' => @existing_roles[name]
+                               })
           end
-        end
 
-        puts "done" if option_verbose?
+          permissions = CSV.parse_line(line[PERMISSIONS], {:skip_blanks => true}).collect do |permission|
+            foreman_permission(:name => permission)
+          end if line[PERMISSIONS]
+          organizations = CSV.parse_line(line[ORGANIZATIONS], {:skip_blanks => true}).collect do |organization|
+            foreman_organization(:name => organization)
+          end if line[ORGANIZATIONS]
+          locations = CSV.parse_line(line[LOCATIONS], {:skip_blanks => true}).collect do |location|
+            foreman_location(:name => location)
+          end if line[LOCATIONS]
+
+          if filter
+            filter_id = foreman_filter(name, :name => filter)
+            if !filter_id
+              @api.resource(:filters).call(:create, {
+                                     'role_id' => @existing_roles[name],
+                                     'search' => filter,
+                                     'organization_ids' => organizations || [],
+                                     'location_ids' => locations || [],
+                                     'permission_ids' => permissions || []
+                                   })
+            else
+              @api.resource(:filters).call(:update, {
+                                     'id' => filter_id,
+                                     'search' => filter,
+                                     'organization_ids' => organizations || [],
+                                     'location_ids' => locations || [],
+                                     'permission_ids' => permissions || []
+                                   })
+            end
+          end
+
+          puts "done" if option_verbose?
+        end
       end
     end
   end
-
-  HammerCLICsv::CsvCommand.subcommand("roles",
-                                      "import or export roles",
-                                      HammerCLICsv::RolesCommand)
 end

--- a/lib/hammer_cli_csv/subscriptions.rb
+++ b/lib/hammer_cli_csv/subscriptions.rb
@@ -27,29 +27,30 @@ require 'csv'
 require 'uri'
 
 module HammerCLICsv
-  class SubscriptionsCommand < BaseCommand
+  class CsvCommand
+    class SubscriptionsCommand < BaseCommand
 
-    ORGANIZATION = 'Organization'
-    MANIFEST = 'Manifest File'
+      command_name "subscriptions"
+      desc         "import or export subscriptions"
 
-    def export
-      # TODO
-    end
+      ORGANIZATION = 'Organization'
+      MANIFEST = 'Manifest File'
 
-    def import
-      thread_import do |line|
-        create_subscriptions_from_csv(line)
+      def export
+        # TODO
+      end
+
+      def import
+        thread_import do |line|
+          create_subscriptions_from_csv(line)
+        end
+      end
+
+      def create_subscriptions_from_csv(line)
+        puts "TODO: import #{line[MANIFEST]} into organization #{line[ORGANIZATION]}"
+      rescue RuntimeError => e
+        raise "#{e}\n       #{line}"
       end
     end
-
-    def create_subscriptions_from_csv(line)
-      puts "TODO: import #{line[MANIFEST]} into organization #{line[ORGANIZATION]}"
-    rescue RuntimeError => e
-      raise "#{e}\n       #{line}"
-    end
   end
-
-  HammerCLICsv::CsvCommand.subcommand("subscriptions",
-                                      "import or export subscriptions",
-                                      HammerCLICsv::SubscriptionsCommand)
 end

--- a/lib/hammer_cli_csv/systems.rb
+++ b/lib/hammer_cli_csv/systems.rb
@@ -32,204 +32,205 @@ require 'csv'
 require 'uri'
 
 module HammerCLICsv
-  class SystemsCommand < BaseCommand
-    ORGANIZATION = 'Organization'
-    ENVIRONMENT = 'Environment'
-    CONTENTVIEW = 'Content View'
-    SYSTEMGROUPS = 'System Groups'
-    VIRTUAL = 'Virtual'
-    HOST = 'Host'
-    OPERATINGSYSTEM = 'OS'
-    ARCHITECTURE = 'Arch'
-    SOCKETS = 'Sockets'
-    RAM = 'RAM'
-    CORES = 'Cores'
-    SLA = 'SLA'
-    PRODUCTS = 'Products'
-    SUBSCRIPTIONS = 'Subscriptions'
+  class CsvCommand
+    class SystemsCommand < BaseCommand
+      command_name 'systems'
+      desc         'import or export systems'
 
-    def export
-      CSV.open(option_csv_file || '/dev/stdout', 'wb', {:force_quotes => false}) do |csv|
-        csv << [NAME, COUNT, ORGANIZATION, ENVIRONMENT, CONTENTVIEW, SYSTEMGROUPS, VIRTUAL, HOST,
-                OPERATINGSYSTEM, ARCHITECTURE, SOCKETS, RAM, CORES, SLA, PRODUCTS, SUBSCRIPTIONS]
-        @api.resource(:organizations).call(:index, {:per_page => 999999})['results'].each do |organization|
-          @api.resource(:systems).call(:index, {
-                                'per_page' => 999999,
-                                'organization_id' => katello_organization(:name => organization['name'])
-                               })['results'].each do |system|
-            system = @api.resource(:systems).call(:show, {
-                                          'id' => system['uuid'],
-                                          'fields' => 'full'
-                                        })
+      ORGANIZATION = 'Organization'
+      ENVIRONMENT = 'Environment'
+      CONTENTVIEW = 'Content View'
+      SYSTEMGROUPS = 'System Groups'
+      VIRTUAL = 'Virtual'
+      HOST = 'Host'
+      OPERATINGSYSTEM = 'OS'
+      ARCHITECTURE = 'Arch'
+      SOCKETS = 'Sockets'
+      RAM = 'RAM'
+      CORES = 'Cores'
+      SLA = 'SLA'
+      PRODUCTS = 'Products'
+      SUBSCRIPTIONS = 'Subscriptions'
 
-            name = system['name']
-            count = 1
-            organization_name = organization['name']
-            environment = system['environment']['label']
-            contentview = system['content_view']['name']
-            systemgroups = CSV.generate do |column|
-              column << system['systemGroups'].collect do |systemgroup|
-                systemgroup['name']
+      def export
+        CSV.open(option_csv_file || '/dev/stdout', 'wb', {:force_quotes => false}) do |csv|
+          csv << [NAME, COUNT, ORGANIZATION, ENVIRONMENT, CONTENTVIEW, SYSTEMGROUPS, VIRTUAL, HOST,
+                  OPERATINGSYSTEM, ARCHITECTURE, SOCKETS, RAM, CORES, SLA, PRODUCTS, SUBSCRIPTIONS]
+          @api.resource(:organizations).call(:index, {:per_page => 999999})['results'].each do |organization|
+            @api.resource(:systems).call(:index, {
+                                  'per_page' => 999999,
+                                  'organization_id' => katello_organization(:name => organization['name'])
+                                 })['results'].each do |system|
+              system = @api.resource(:systems).call(:show, {
+                                            'id' => system['uuid'],
+                                            'fields' => 'full'
+                                          })
+
+              name = system['name']
+              count = 1
+              organization_name = organization['name']
+              environment = system['environment']['label']
+              contentview = system['content_view']['name']
+              systemgroups = CSV.generate do |column|
+                column << system['systemGroups'].collect do |systemgroup|
+                  systemgroup['name']
+                end
               end
-            end
-            systemgroups.delete!("\n")
-            virtual = system['facts']['virt.is_guest'] == 'true' ? 'Yes' : 'No'
-            host = system['host']
-            operatingsystem = "#{system['facts']['distribution.name']} " if system['facts']['distribution.name']
-            operatingsystem += system['facts']['distribution.version'] if system['facts']['distribution.version']
-            architecture = system['facts']['uname.machine']
-            sockets = system['facts']['cpu.cpu_socket(s)']
-            ram = system['facts']['memory.memtotal']
-            cores = system['facts']['cpu.core(s)_per_socket']
-            sla = ''
-            products = CSV.generate do |column|
-              column << system['installedProducts'].collect do |product|
-                "#{product['productId']}|#{product['productName']}"
+              systemgroups.delete!("\n")
+              virtual = system['facts']['virt.is_guest'] == 'true' ? 'Yes' : 'No'
+              host = system['host']
+              operatingsystem = "#{system['facts']['distribution.name']} " if system['facts']['distribution.name']
+              operatingsystem += system['facts']['distribution.version'] if system['facts']['distribution.version']
+              architecture = system['facts']['uname.machine']
+              sockets = system['facts']['cpu.cpu_socket(s)']
+              ram = system['facts']['memory.memtotal']
+              cores = system['facts']['cpu.core(s)_per_socket']
+              sla = ''
+              products = CSV.generate do |column|
+                column << system['installedProducts'].collect do |product|
+                  "#{product['productId']}|#{product['productName']}"
+                end
               end
-            end
-            products.delete!("\n")
-            subscriptions = CSV.generate do |column|
-              column << @api.resource(:subscriptions).call(:index, {
-                                                    'system_id' => system['uuid']
-                                                  })['results'].collect do |subscription|
-                "#{subscription['product_id']}|#{subscription['product_name']}"
+              products.delete!("\n")
+              subscriptions = CSV.generate do |column|
+                column << @api.resource(:subscriptions).call(:index, {
+                                                      'system_id' => system['uuid']
+                                                    })['results'].collect do |subscription|
+                  "#{subscription['product_id']}|#{subscription['product_name']}"
+                end
               end
+              subscriptions.delete!("\n")
+              csv << [name, count, organization_name, environment, contentview, systemgroups, virtual, host,
+                      operatingsystem, architecture, sockets, ram, cores, sla, products, subscriptions]
             end
-            subscriptions.delete!("\n")
-            csv << [name, count, organization_name, environment, contentview, systemgroups, virtual, host,
-                    operatingsystem, architecture, sockets, ram, cores, sla, products, subscriptions]
           end
         end
       end
-    end
 
-    def import
-      @existing = {}
-      @host_guests = {}
+      def import
+        @existing = {}
+        @host_guests = {}
 
-      thread_import do |line|
-        create_systems_from_csv(line)
-      end
-
-      print 'Updating host and guest associations...' if option_verbose?
-      @host_guests.each do |host_id, guest_ids|
-        @api.resource(:systems).call(:update, {
-                               'id' => host_id,
-                               'guest_ids' => guest_ids
-                             })
-      end
-      puts 'done' if option_verbose?
-    end
-
-    def create_systems_from_csv(line)
-      if !@existing[line[ORGANIZATION]]
-        @existing[line[ORGANIZATION]] = {}
-        @api.resource(:systems).call(:index, {
-                              'organization_id' => katello_organization(:name => line[ORGANIZATION]),
-                              'page_size' => 999999})['results'].each do |system|
-          @existing[line[ORGANIZATION]][system['name']] = system['uuid'] if system
+        thread_import do |line|
+          create_systems_from_csv(line)
         end
+
+        print 'Updating host and guest associations...' if option_verbose?
+        @host_guests.each do |host_id, guest_ids|
+          @api.resource(:systems).call(:update, {
+                                 'id' => host_id,
+                                 'guest_ids' => guest_ids
+                               })
+        end
+        puts 'done' if option_verbose?
       end
 
-      line[COUNT].to_i.times do |number|
-        name = namify(line[NAME], number)
+      def create_systems_from_csv(line)
+        if !@existing[line[ORGANIZATION]]
+          @existing[line[ORGANIZATION]] = {}
+          @api.resource(:systems).call(:index, {
+                                'organization_id' => katello_organization(:name => line[ORGANIZATION]),
+                                'page_size' => 999999})['results'].each do |system|
+            @existing[line[ORGANIZATION]][system['name']] = system['uuid'] if system
+          end
+        end
 
-        # TODO w/ @daviddavis p-r
-        #subscriptions(line).each do |subscription|
-        #  katello_subscription(line[ORGANIZATION], :name => subscription[:number])
-        #end
+        line[COUNT].to_i.times do |number|
+          name = namify(line[NAME], number)
 
-        if !@existing[line[ORGANIZATION]].include? name
-          print "Creating system '#{name}'..." if option_verbose?
-          system_id = @api.resource(:systems).call(:create, {
-                                                     'name' => name,
-                                                     'organization_id' => katello_organization(:name => line[ORGANIZATION]),
-                                                     'environment_id' => katello_environment(line[ORGANIZATION], :name => line[ENVIRONMENT]),
-                                                     'content_view_id' => katello_contentview(line[ORGANIZATION], :name => line[CONTENTVIEW]),
-                                                     'facts' => facts(name, line),
-                                                     'installed_products' => products(line),
-                                                     'type' => 'system'
-                                                   })['uuid']
-          @existing[line[ORGANIZATION]][name] = system_id
-        else
-          print "Updating system '#{name}'..." if option_verbose?
-          system_id = @api.resource(:systems).call(:update, {
-                                                     'id' => @existing[line[ORGANIZATION]][name],
-                                                     'system' => {
+          # TODO w/ @daviddavis p-r
+          #subscriptions(line).each do |subscription|
+          #  katello_subscription(line[ORGANIZATION], :name => subscription[:number])
+          #end
+
+          if !@existing[line[ORGANIZATION]].include? name
+            print "Creating system '#{name}'..." if option_verbose?
+            system_id = @api.resource(:systems).call(:create, {
                                                        'name' => name,
+                                                       'organization_id' => katello_organization(:name => line[ORGANIZATION]),
                                                        'environment_id' => katello_environment(line[ORGANIZATION], :name => line[ENVIRONMENT]),
                                                        'content_view_id' => katello_contentview(line[ORGANIZATION], :name => line[CONTENTVIEW]),
                                                        'facts' => facts(name, line),
-                                                       'installed_products' => products(line)
-                                                     }
-                                                   })['uuid']
+                                                       'installed_products' => products(line),
+                                                       'type' => 'system'
+                                                     })['uuid']
+            @existing[line[ORGANIZATION]][name] = system_id
+          else
+            print "Updating system '#{name}'..." if option_verbose?
+            system_id = @api.resource(:systems).call(:update, {
+                                                       'id' => @existing[line[ORGANIZATION]][name],
+                                                       'system' => {
+                                                         'name' => name,
+                                                         'environment_id' => katello_environment(line[ORGANIZATION], :name => line[ENVIRONMENT]),
+                                                         'content_view_id' => katello_contentview(line[ORGANIZATION], :name => line[CONTENTVIEW]),
+                                                         'facts' => facts(name, line),
+                                                         'installed_products' => products(line)
+                                                       }
+                                                     })['uuid']
+          end
+
+          if line[VIRTUAL] == 'Yes' && line[HOST]
+            raise "Host system '#{line[HOST]}' not found" if !@existing[line[ORGANIZATION]][line[HOST]]
+            @host_guests[@existing[line[ORGANIZATION]][line[HOST]]] ||= []
+            @host_guests[@existing[line[ORGANIZATION]][line[HOST]]] << system_id
+          end
+
+          set_system_groups(system_id, line)
+
+          puts 'done' if option_verbose?
         end
+      rescue RuntimeError => e
+        raise "#{e}\n       #{line}"
+      end
 
-        if line[VIRTUAL] == 'Yes' && line[HOST]
-          raise "Host system '#{line[HOST]}' not found" if !@existing[line[ORGANIZATION]][line[HOST]]
-          @host_guests[@existing[line[ORGANIZATION]][line[HOST]]] ||= []
-          @host_guests[@existing[line[ORGANIZATION]][line[HOST]]] << system_id
+      private
+
+      def facts(name, line)
+        facts = {}
+        facts['cpu.core(s)_per_socket'] = line[CORES]
+        facts['cpu.cpu_socket(s)'] = line[SOCKETS]
+        facts['memory.memtotal'] = line[RAM]
+        facts['uname.machine'] = line[ARCHITECTURE]
+        if line[OPERATINGSYSTEM].index(' ')
+          (facts['distribution.name'], facts['distribution.version']) = line[OPERATINGSYSTEM].split(' ')
+        else
+          (facts['distribution.name'], facts['distribution.version']) = ['RHEL', line[OPERATINGSYSTEM]]
         end
-
-        set_system_groups(system_id, line)
-
-        puts 'done' if option_verbose?
+        facts['virt.is_guest'] = line[VIRTUAL] == 'Yes' ? true : false
+        facts['virt.uuid'] = "#{line[ORGANIZATION]}/#{name}" if facts['virt.is_guest']
+        facts
       end
-    rescue RuntimeError => e
-      raise "#{e}\n       #{line}"
-    end
 
-    private
-
-    def facts(name, line)
-      facts = {}
-      facts['cpu.core(s)_per_socket'] = line[CORES]
-      facts['cpu.cpu_socket(s)'] = line[SOCKETS]
-      facts['memory.memtotal'] = line[RAM]
-      facts['uname.machine'] = line[ARCHITECTURE]
-      if line[OPERATINGSYSTEM].index(' ')
-        (facts['distribution.name'], facts['distribution.version']) = line[OPERATINGSYSTEM].split(' ')
-      else
-        (facts['distribution.name'], facts['distribution.version']) = ['RHEL', line[OPERATINGSYSTEM]]
+      def set_system_groups(system_id, line)
+        CSV.parse_line(line[SYSTEMGROUPS]).each do |systemgroup_name|
+          @api.resource(:system_groups).call(:add_systems, {
+                                           'id' => katello_systemgroup(line[ORGANIZATION], :name => systemgroup_name),
+                                           'system_ids' => [system_id]
+                                         })
+        end
       end
-      facts['virt.is_guest'] = line[VIRTUAL] == 'Yes' ? true : false
-      facts['virt.uuid'] = "#{line[ORGANIZATION]}/#{name}" if facts['virt.is_guest']
-      facts
-    end
 
-    def set_system_groups(system_id, line)
-      CSV.parse_line(line[SYSTEMGROUPS]).each do |systemgroup_name|
-        @api.resource(:system_groups).call(:add_systems, {
-                                         'id' => katello_systemgroup(line[ORGANIZATION], :name => systemgroup_name),
-                                         'system_ids' => [system_id]
-                                       })
+      def products(line)
+        return nil if !line[PRODUCTS]
+        products = CSV.parse_line(line[PRODUCTS]).collect do |product_details|
+          product = {}
+          # TODO: these get passed straight through to candlepin; probably would be better to process in server
+          #       to allow underscore product_id here
+          (product['productId'], product['productName']) = product_details.split('|')
+          product
+        end
+        products
       end
-    end
 
-    def products(line)
-      return nil if !line[PRODUCTS]
-      products = CSV.parse_line(line[PRODUCTS]).collect do |product_details|
-        product = {}
-        # TODO: these get passed straight through to candlepin; probably would be better to process in server
-        #       to allow underscore product_id here
-        (product['productId'], product['productName']) = product_details.split('|')
-        product
+      def subscriptions(line)
+        return nil if !line[SUBSCRIPTIONS]
+        subscriptions = CSV.parse_line(line[SUBSCRIPTIONS]).collect do |subscription_details|
+          subscription = {}
+          (subscription[:number], subscription[:name]) = subscription_details.split('|')
+          subscription
+        end
+        subscriptions
       end
-      products
-    end
-
-    def subscriptions(line)
-      return nil if !line[SUBSCRIPTIONS]
-      subscriptions = CSV.parse_line(line[SUBSCRIPTIONS]).collect do |subscription_details|
-        subscription = {}
-        (subscription[:number], subscription[:name]) = subscription_details.split('|')
-        subscription
-      end
-      subscriptions
     end
   end
-
-  HammerCLICsv::CsvCommand.subcommand('systems',
-                                      'import or export systems',
-                                      HammerCLICsv::SystemsCommand)
 end


### PR DESCRIPTION
Most of the 'changed' lines are just re-indented - 'git diff -b' is a better view of the impact

NOTE: 'autoload_subcommands wants to be in only one place -
leave in last-loaded subcommand (in this case, users.rb)

$ env RUBYOPT=-Ilib hammer csv
Usage:
    hammer csv [OPTIONS] SUBCOMMAND [ARG] ...

Parameters:
    SUBCOMMAND                    subcommand
    [ARG] ...                     subcommand arguments

Subcommands:
    activation-keys               import or export activation keys
    architectures                 import or export architectures
    content-views                 import or export content-views
    domains                       import or export domains
    hosts                         import or export hosts
    lifecycle-environment         import or export lifecycle environments
    locations                     import or export locations
    operating-systems             import or export operating systems
    organizations                 import or export organizations
    partition-tables              import or export partition tables
    permissions                   import or export permissions
    products                      import or export products
    puppet-environments           import or export puppet environments
    puppet-facts                  import or export puppet facts
    puppet-reports                import or export puppet reports
    reports                       import or export reports
    roles                         import or export roles
    subscriptions                 import or export subscriptions
    system-groups                 import or export system groups
    systems                       import or export systems
    users                         import or export users

Options:
    -h, --help                    print help
