### PR TITLE
SAM export system groups to host collections

### DIFF
--- a/lib/hammer_cli_csv/organizations.rb
+++ b/lib/hammer_cli_csv/organizations.rb
@@ -74,16 +74,22 @@ module HammerCLICsv
           if !@existing.include? name
             print "Creating organization '#{name}'... " if option_verbose?
             @api.resource(:organizations).call(:create, {
-                                         'name' => name,
-                                         'label' => label,
-                                         'description' => line[DESCRIPTION]
-                                       })
+                'name' => name,
+                'organization' => {
+                    'name' => name,
+                    'label' => label,
+                    'description' => line[DESCRIPTION]
+                }
+            })
           else
             print "Updating organization '#{name}'... " if option_verbose?
             @api.resource(:organizations).call(:update, {
-                                         'id' => label,
-                                         'description' => line[DESCRIPTION]
-                                       })
+                'id' => foreman_organization(:name => name),
+                'organization' => {
+                    'id' => foreman_organization(:name => name),
+                    'description' => line[DESCRIPTION]
+                }
+            })
           end
           print "done\n" if option_verbose?
         end


### PR DESCRIPTION
- corrected CLI params to properly read server, username, and password
- awful work-around for organizations API requiring nested _and_ unnested param
- minor code style update (to remove .call on separate line)
