### PR TITLE
fixes #15752 - continue processing even if error

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Supported commands and options are available by using the --help option. Additio
 | --username USERNAME | Username for server. Overrides any config file value. |
 | --password PASSWORD | Password for user. Overrides any config file value. |
 | --verbose | Display verbose progress information during import. |
+| --continue-on-error | Continue processing even if individual resource error |
 
 ## Count Substitution
 

--- a/lib/hammer_cli_csv/architectures.rb
+++ b/lib/hammer_cli_csv/architectures.rb
@@ -54,8 +54,6 @@ module HammerCLICsv
           end
           print "done\n" if option_verbose?
         end
-      rescue RuntimeError => e
-        raise "#{e}\n       #{line}"
       end
     end
   end

--- a/lib/hammer_cli_csv/compute_profiles.rb
+++ b/lib/hammer_cli_csv/compute_profiles.rb
@@ -65,8 +65,6 @@ module HammerCLICsv
 
           print "done\n" if option_verbose?
         end
-      rescue RuntimeError => e
-        raise "#{e}\n       #{line}"
       end
     end
   end

--- a/lib/hammer_cli_csv/compute_resources.rb
+++ b/lib/hammer_cli_csv/compute_resources.rb
@@ -67,8 +67,6 @@ module HammerCLICsv
 
           print "done\n" if option_verbose?
         end
-      rescue RuntimeError => e
-        raise "#{e}\n       #{line}"
       end
     end
   end

--- a/lib/hammer_cli_csv/content_hosts.rb
+++ b/lib/hammer_cli_csv/content_hosts.rb
@@ -207,8 +207,6 @@ module HammerCLICsv
         update_subscriptions(host, line, true)
 
         puts _('done') if option_verbose?
-      rescue RuntimeError => e
-        raise "#{e}\n       #{line}"
       end
 
       def facts(name, line)

--- a/lib/hammer_cli_csv/content_view_filters.rb
+++ b/lib/hammer_cli_csv/content_view_filters.rb
@@ -153,8 +153,6 @@ module HammerCLICsv
           puts 'done' if option_verbose?
         end
 
-      rescue RuntimeError => e
-        raise "#{e}\n       #{line}"
       end
 
       private

--- a/lib/hammer_cli_csv/content_views.rb
+++ b/lib/hammer_cli_csv/content_views.rb
@@ -129,8 +129,6 @@ module HammerCLICsv
           puts _('done') if option_verbose?
         end
 
-      rescue RuntimeError => e
-        raise "#{e}\n       #{line}"
       end
 
       def environment_names(contentview)

--- a/lib/hammer_cli_csv/domains.rb
+++ b/lib/hammer_cli_csv/domains.rb
@@ -90,8 +90,6 @@ module HammerCLICsv
 
           print "done\n" if option_verbose?
         end
-      rescue RuntimeError => e
-        raise "#{e}\n       #{line}"
       end
 
       private

--- a/lib/hammer_cli_csv/host_groups.rb
+++ b/lib/hammer_cli_csv/host_groups.rb
@@ -117,8 +117,6 @@ module HammerCLICsv
 
           print "done\n" if option_verbose?
         end
-      rescue RuntimeError => e
-        raise "#{e}\n       #{line}"
       end
     end
   end

--- a/lib/hammer_cli_csv/hosts.rb
+++ b/lib/hammer_cli_csv/hosts.rb
@@ -108,8 +108,6 @@ module HammerCLICsv
           end
           print "done\n" if option_verbose?
         end
-      rescue RuntimeError => e
-        raise "#{e}\n       #{line}"
       end
     end
   end

--- a/lib/hammer_cli_csv/installation_media.rb
+++ b/lib/hammer_cli_csv/installation_media.rb
@@ -68,8 +68,6 @@ module HammerCLICsv
           end
           puts _('done') if option_verbose?
         end
-      rescue RuntimeError => e
-        raise "#{e}\n       #{line}"
       end
     end
   end

--- a/lib/hammer_cli_csv/job_templates.rb
+++ b/lib/hammer_cli_csv/job_templates.rb
@@ -136,8 +136,6 @@ module HammerCLICsv
           # end
 
         end
-      rescue RuntimeError => e
-        raise "#{e}\n       #{line[NAME]}"
       end
 
       def create_template(line, number)

--- a/lib/hammer_cli_csv/lifecycle_environments.rb
+++ b/lib/hammer_cli_csv/lifecycle_environments.rb
@@ -74,8 +74,6 @@ module HammerCLICsv
           end
           print "done\n" if option_verbose?
         end
-      rescue RuntimeError => e
-        raise "#{e}\n       #{line}"
       end
     end
   end

--- a/lib/hammer_cli_csv/operating_systems.rb
+++ b/lib/hammer_cli_csv/operating_systems.rb
@@ -80,8 +80,6 @@ module HammerCLICsv
           end
           print "done\n" if option_verbose?
         end
-      rescue RuntimeError => e
-        raise "#{e}\n       #{line}"
       end
     end
   end

--- a/lib/hammer_cli_csv/partition_tables.rb
+++ b/lib/hammer_cli_csv/partition_tables.rb
@@ -100,8 +100,6 @@ module HammerCLICsv
           end
           print "done\n" if option_verbose?
         end
-      rescue RuntimeError => e
-        raise "#{e}\n       #{line}"
       end
     end
   end

--- a/lib/hammer_cli_csv/products.rb
+++ b/lib/hammer_cli_csv/products.rb
@@ -66,8 +66,6 @@ module HammerCLICsv
           puts _('done') if option_verbose?
         end
 
-      rescue RuntimeError => e
-        raise "#{e}\n       #{line}"
       end
 
       private
@@ -264,8 +262,6 @@ module HammerCLICsv
                    --organization-id #{ foreman_organization(:name => line[ORGANIZATION]) } }
         hammer.run(args)
 
-      rescue RuntimeError => e
-        raise "#{e}\n       #{line}"
       end
 
       def get_content_set(organization, product, repository)

--- a/lib/hammer_cli_csv/provisioning_templates.rb
+++ b/lib/hammer_cli_csv/provisioning_templates.rb
@@ -138,8 +138,6 @@ module HammerCLICsv
 
           puts _('done') if option_verbose?
         end
-      rescue RuntimeError => e
-        raise "#{e}\n       #{line[NAME]}"
       end
 
       def export_associations(template)

--- a/lib/hammer_cli_csv/puppet_environments.rb
+++ b/lib/hammer_cli_csv/puppet_environments.rb
@@ -72,8 +72,6 @@ module HammerCLICsv
 
           puts "done" if option_verbose?
         end
-      rescue RuntimeError => e
-        raise "#{e}\n       #{line}"
       end
     end
   end

--- a/lib/hammer_cli_csv/puppet_facts.rb
+++ b/lib/hammer_cli_csv/puppet_facts.rb
@@ -67,8 +67,6 @@ module HammerCLICsv
                                              })
           print "done\n" if option_verbose?
         end
-      rescue RuntimeError => e
-        raise "#{e}\n       #{line}"
       end
     end
   end

--- a/lib/hammer_cli_csv/puppet_reports.rb
+++ b/lib/hammer_cli_csv/puppet_reports.rb
@@ -145,8 +145,6 @@ module HammerCLICsv
 
           puts 'done' if option_verbose?
         end
-      rescue RuntimeError => e
-        raise "#{e}\n       #{line}"
       end
 
       private

--- a/lib/hammer_cli_csv/smart_proxies.rb
+++ b/lib/hammer_cli_csv/smart_proxies.rb
@@ -61,8 +61,6 @@ module HammerCLICsv
 
           print "done\n" if option_verbose?
         end
-      rescue RuntimeError => e
-        raise "#{e}\n       #{line}"
       end
     end
   end

--- a/lib/hammer_cli_csv/splice.rb
+++ b/lib/hammer_cli_csv/splice.rb
@@ -130,8 +130,6 @@ module HammerCLICsv
         update_host_collections(host_id, line)
 
         puts _('done') if option_verbose?
-      rescue RuntimeError => e
-        raise "#{e}\n       #{line}"
       end
 
       private

--- a/lib/hammer_cli_csv/subnets.rb
+++ b/lib/hammer_cli_csv/subnets.rb
@@ -98,8 +98,6 @@ module HammerCLICsv
 
           print "done\n" if option_verbose?
         end
-      rescue RuntimeError => e
-        raise "#{e}\n       #{line}"
       end
     end
   end

--- a/lib/hammer_cli_csv/subscriptions.rb
+++ b/lib/hammer_cli_csv/subscriptions.rb
@@ -66,8 +66,6 @@ module HammerCLICsv
         }
         hammer.run(args)
 
-      rescue RuntimeError => e
-        raise "#{e}\n       #{line}"
       end
     end
   end

--- a/lib/hammer_cli_csv/sync_plans.rb
+++ b/lib/hammer_cli_csv/sync_plans.rb
@@ -87,8 +87,6 @@ module HammerCLICsv
           puts "done" if option_verbose?
         end
 
-      rescue RuntimeError => e
-        raise "#{e}\n       #{line}"
       end
 
       private

--- a/lib/hammer_cli_csv/users.rb
+++ b/lib/hammer_cli_csv/users.rb
@@ -79,8 +79,6 @@ module HammerCLICsv
           end
           print "done\n" if option_verbose?
         end
-      rescue RuntimeError => e
-        raise "#{e}\n       #{line}"
       end
 
       def create_user(line, name, roles, organizations, locations)

--- a/test/data/settings.csv
+++ b/test/data/settings.csv
@@ -1,2 +1,3 @@
 Name,Count,Value
+xyz,1,123
 idle_timeout,1,60000

--- a/test/fixtures/vcr_cassettes/apipie.yml
+++ b/test/fixtures/vcr_cassettes/apipie.yml
@@ -39,9 +39,9 @@ http_interactions:
       Apipie-Checksum:
       - e98945ba1db6bdbb4c25ce4988912344
       X-Request-Id:
-      - be669e66-8be8-4a3a-8168-a4636201a334
+      - 645d6788-1dd0-4765-a41c-b982f63614a5
       X-Runtime:
-      - '0.282461'
+      - '0.224373'
       Transfer-Encoding:
       - chunked
     body:
@@ -18524,5 +18524,5 @@ http_interactions:
         bnVsbCwic2VlIjpbXSwiaGVhZGVycyI6W10sInNob3ciOnRydWV9XSwiaGVh
         ZGVycyI6bnVsbH19LCJsaW5rX2V4dGVuc2lvbiI6Ii5lbi5odG1sIn19
     http_version: 
-  recorded_at: Tue, 16 Aug 2016 19:11:44 GMT
+  recorded_at: Tue, 23 Aug 2016 12:27:04 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/resources/settings_import/update_settings.yml
+++ b/test/fixtures/vcr_cassettes/resources/settings_import/update_settings.yml
@@ -1,6 +1,256 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://admin:changeme@katello:3000/api/settings/104
+    body:
+      encoding: UTF-8
+      string: '{"setting":{"value":"60000"}}'
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '29'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Foreman-Version:
+      - 1.13.0-develop
+      Foreman-Api-Version:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      Apipie-Checksum:
+      - e98945ba1db6bdbb4c25ce4988912344
+      Etag:
+      - W/"fad2d243311537e4336d8fdd609f58db"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Set-Cookie:
+      - _session_id=3bd66552dd1479004842de123877b27c; path=/; HttpOnly
+      - request_method=PUT; path=/
+      X-Request-Id:
+      - 22959f07-f544-4d77-bce4-54f9f908e55c
+      X-Runtime:
+      - '1.433806'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"value":60000,"description":"Log out idle users after a certain number
+        of minutes","category":"Setting::Auth","settings_type":"integer","default":60,"created_at":"2016-07-15
+        13:17:56 UTC","updated_at":"2016-07-15 13:38:43 UTC","id":104,"name":"idle_timeout"}'
+    http_version:
+  recorded_at: Wed, 03 Aug 2016 18:37:06 GMT
+- request:
+    method: get
+    uri: http://admin:changeme@katello:3000/api/status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Foreman-Version:
+      - 1.13.0-develop
+      Foreman-Api-Version:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      Apipie-Checksum:
+      - e98945ba1db6bdbb4c25ce4988912344
+      Etag:
+      - W/"f536fd8685b76bb26a943d472593c93e"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Set-Cookie:
+      - _session_id=debcf6aad8756b41c3f13af385bab84e; path=/; HttpOnly
+      X-Request-Id:
+      - 71a5d376-c714-402f-8cb9-88abae35f646
+      X-Runtime:
+      - '0.207556'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"result":"ok","status":200,"version":"1.13.0-develop","api_version":2}'
+    http_version:
+  recorded_at: Tue, 23 Aug 2016 12:27:06 GMT
+- request:
+    method: get
+    uri: http://admin:changeme@katello:3000/api/v2/plugins
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Foreman-Version:
+      - 1.13.0-develop
+      Foreman-Api-Version:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      Apipie-Checksum:
+      - e98945ba1db6bdbb4c25ce4988912344
+      Etag:
+      - W/"5fdeea8a610f7805000b37060cecd4be"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Set-Cookie:
+      - _session_id=88376faf79d6c8bbfdd82b5e739cf005; path=/; HttpOnly
+      X-Request-Id:
+      - 8eea7dcf-e74f-4188-aa89-4b0aa6ad610f
+      X-Runtime:
+      - '0.258911'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJ0b3RhbCI6IDQsCiAgInN1YnRvdGFsIjogNCwKICAicGFnZSI6IDEs
+        CiAgInBlcl9wYWdlIjogMjAsCiAgInNlYXJjaCI6IG51bGwsCiAgInNvcnQi
+        OiB7CiAgICAiYnkiOiBudWxsLAogICAgIm9yZGVyIjogbnVsbAogIH0sCiAg
+        InJlc3VsdHMiOiBbeyJpZCI6ImZvcmVtYW4tdGFza3MiLCJuYW1lIjoiZm9y
+        ZW1hbi10YXNrcyIsImF1dGhvciI6Ikl2YW4gTmXEjWFzIiwiZGVzY3JpcHRp
+        b24iOiJUaGUgZ29hbCBvZiB0aGlzIHBsdWdpbiBpcyB0byB1bmlmeSB0aGUg
+        d2F5IG9mIHNob3dpbmcgdGFzayBzdGF0dXNlcyBhY3Jvc3MgdGhlIEZvcmVt
+        YW4gaW5zdGFuY2UuXG5JdCBkZWZpbmVzIFRhc2sgbW9kZWwgZm9yIGtlZXBp
+        bmcgdGhlIGluZm9ybWF0aW9uIGFib3V0IHRoZSB0YXNrcyBhbmQgTG9jayBm
+        b3IgYXNzaWduaW5nIHRoZSB0YXNrc1xudG8gcmVzb3VyY2VzLiBUaGUgbG9j
+        a2luZyBhbGxvd3MgZGVhbGluZyB3aXRoIHByZXZlbnRpbmcgbXVsdGlwbGUg
+        Y29sbGlkaW5nIHRhc2tzIHRvIGJlIHJ1biBvbiB0aGVcbnNhbWUgcmVzb3Vy
+        Y2UuIEl0IGFsc28gb3B0aW9uYWxseSBwcm92aWRlcyBEeW5mbG93IGluZnJh
+        c3RydWN0dXJlIGZvciB1c2luZyBpdCBmb3IgbWFuYWdpbmcgdGhlIHRhc2tz
+        LlxuIiwidXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL3RoZWZvcmVtYW4vZm9y
+        ZW1hbi10YXNrcyIsInZlcnNpb24iOiIwLjguMCJ9LHsiaWQiOiJmb3JlbWFu
+        X2RvY2tlciIsIm5hbWUiOiJmb3JlbWFuX2RvY2tlciIsImF1dGhvciI6IkRh
+        bmllbCBMb2JhdG8sIEFtb3MgQmVuYXJpIiwiZGVzY3JpcHRpb24iOiJQcm92
+        aXNpb24gYW5kIG1hbmFnZSBEb2NrZXIgY29udGFpbmVycyBhbmQgaW1hZ2Vz
+        IGZyb20gRm9yZW1hbi4iLCJ1cmwiOiJodHRwOi8vZ2l0aHViLmNvbS90aGVm
+        b3JlbWFuL2ZvcmVtYW4tZG9ja2VyIiwidmVyc2lvbiI6IjMuMC4wIn0seyJp
+        ZCI6ImZvcmVtYW5fcmVtb3RlX2V4ZWN1dGlvbiIsIm5hbWUiOiJmb3JlbWFu
+        X3JlbW90ZV9leGVjdXRpb24iLCJhdXRob3IiOiJGb3JlbWFuIFJlbW90ZSBF
+        eGVjdXRpb24gdGVhbSIsImRlc2NyaXB0aW9uIjoiQSBwbHVnaW4gYnJpbmdp
+        bmcgcmVtb3RlIGV4ZWN1dGlvbiB0byB0aGUgRm9yZW1hbiwgY29tcGxldGlu
+        ZyB0aGUgY29uZmlnIG1hbmFnZW1lbnQgZnVuY3Rpb25hbGl0eSB3aXRoIHJl
+        bW90ZSBtYW5hZ2VtZW50IGZ1bmN0aW9uYWxpdHkuIiwidXJsIjoiaHR0cHM6
+        Ly9naXRodWIuY29tL3RoZWZvcmVtYW4vZm9yZW1hbl9yZW1vdGVfZXhlY3V0
+        aW9uIiwidmVyc2lvbiI6IjEuMC4wIn0seyJpZCI6ImthdGVsbG8iLCJuYW1l
+        Ijoia2F0ZWxsbyIsImF1dGhvciI6Ik4vQSIsImRlc2NyaXB0aW9uIjoiQ29u
+        dGVudCBhbmQgU3Vic2NyaXB0aW9uIE1hbmFnZW1lbnQgcGx1Z2luIGZvciBG
+        b3JlbWFuIiwidXJsIjoiaHR0cDovL3d3dy5rYXRlbGxvLm9yZyIsInZlcnNp
+        b24iOiIzLjIuMCJ9XQp9Cg==
+    http_version:
+  recorded_at: Tue, 23 Aug 2016 12:27:06 GMT
+- request:
+    method: get
+    uri: http://admin:changeme@katello:3000/api/settings?search=name=%22idle_timeout%22
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Foreman-Version:
+      - 1.13.0-develop
+      Foreman-Api-Version:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      Apipie-Checksum:
+      - e98945ba1db6bdbb4c25ce4988912344
+      Etag:
+      - W/"36e0831745e01f3460c82a79d66680fb"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Set-Cookie:
+      - _session_id=f6c64e0318b837ee51a30c0bc3462d79; path=/; HttpOnly
+      X-Request-Id:
+      - a06a4276-15a6-495d-a63d-c3530b638bdc
+      X-Runtime:
+      - '0.281033'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "total": 106,
+          "subtotal": 1,
+          "page": 1,
+          "per_page": 20,
+          "search": "name=\"idle_timeout\"",
+          "sort": {
+            "by": null,
+            "order": null
+          },
+          "results": [{"value":60000,"description":"Log out idle users after a certain number of minutes","category":"Setting::Auth","settings_type":"integer","default":60,"created_at":"2016-08-10 12:38:11 UTC","updated_at":"2016-08-10 13:34:48 UTC","id":99,"name":"idle_timeout"}]
+        }
+    http_version:
+  recorded_at: Tue, 23 Aug 2016 12:27:07 GMT
+- request:
     method: get
     uri: http://admin:changeme@katello:3000/apidoc/v2.json
     body:
@@ -37,9 +287,9 @@ http_interactions:
       Apipie-Checksum:
       - e98945ba1db6bdbb4c25ce4988912344
       X-Request-Id:
-      - cafa3e3b-22c6-493d-8221-c9ea03e9f468
+      - e18b2e18-9920-443d-b53e-ee03ec0cf9c1
       X-Runtime:
-      - '0.131546'
+      - '0.146171'
       Transfer-Encoding:
       - chunked
     body:
@@ -18522,204 +18772,10 @@ http_interactions:
         bnVsbCwic2VlIjpbXSwiaGVhZGVycyI6W10sInNob3ciOnRydWV9XSwiaGVh
         ZGVycyI6bnVsbH19LCJsaW5rX2V4dGVuc2lvbiI6Ii5odG1sIn19
     http_version: 
-  recorded_at: Tue, 02 Aug 2016 17:16:27 GMT
-- request:
-    method: get
-    uri: http://admin:changeme@katello:3000/api/status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      Foreman-Version:
-      - 1.13.0-develop
-      Foreman-Api-Version:
-      - '2'
-      Content-Type:
-      - application/json; charset=utf-8
-      Apipie-Checksum:
-      - e98945ba1db6bdbb4c25ce4988912344
-      Etag:
-      - W/"f536fd8685b76bb26a943d472593c93e"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Set-Cookie:
-      - _session_id=33b5190d7df9cd4cd969a9d2421f28ae; path=/; HttpOnly
-      X-Request-Id:
-      - 2b53b0eb-7189-40b5-aae5-87dbfc023cc1
-      X-Runtime:
-      - '0.224774'
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: '{"result":"ok","status":200,"version":"1.13.0-develop","api_version":2}'
-    http_version: 
-  recorded_at: Wed, 03 Aug 2016 18:37:03 GMT
-- request:
-    method: get
-    uri: http://admin:changeme@katello:3000/api/v2/plugins
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      Foreman-Version:
-      - 1.13.0-develop
-      Foreman-Api-Version:
-      - '2'
-      Content-Type:
-      - application/json; charset=utf-8
-      Apipie-Checksum:
-      - e98945ba1db6bdbb4c25ce4988912344
-      Etag:
-      - W/"85abe67b01ef6683a42df854df2005a3"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Set-Cookie:
-      - _session_id=fcf2fdeb7d16c802f12b5fd7054317f6; path=/; HttpOnly
-      X-Request-Id:
-      - a95f47a0-74c4-4e5b-bb03-4992b1d3f954
-      X-Runtime:
-      - '0.215053'
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        ewogICJ0b3RhbCI6IDQsCiAgInN1YnRvdGFsIjogNCwKICAicGFnZSI6IDEs
-        CiAgInBlcl9wYWdlIjogMjAsCiAgInNlYXJjaCI6IG51bGwsCiAgInNvcnQi
-        OiB7CiAgICAiYnkiOiBudWxsLAogICAgIm9yZGVyIjogbnVsbAogIH0sCiAg
-        InJlc3VsdHMiOiBbeyJpZCI6ImZvcmVtYW4tdGFza3MiLCJuYW1lIjoiZm9y
-        ZW1hbi10YXNrcyIsImF1dGhvciI6Ikl2YW4gTmXEjWFzIiwiZGVzY3JpcHRp
-        b24iOiJUaGUgZ29hbCBvZiB0aGlzIHBsdWdpbiBpcyB0byB1bmlmeSB0aGUg
-        d2F5IG9mIHNob3dpbmcgdGFzayBzdGF0dXNlcyBhY3Jvc3MgdGhlIEZvcmVt
-        YW4gaW5zdGFuY2UuXG5JdCBkZWZpbmVzIFRhc2sgbW9kZWwgZm9yIGtlZXBp
-        bmcgdGhlIGluZm9ybWF0aW9uIGFib3V0IHRoZSB0YXNrcyBhbmQgTG9jayBm
-        b3IgYXNzaWduaW5nIHRoZSB0YXNrc1xudG8gcmVzb3VyY2VzLiBUaGUgbG9j
-        a2luZyBhbGxvd3MgZGVhbGluZyB3aXRoIHByZXZlbnRpbmcgbXVsdGlwbGUg
-        Y29sbGlkaW5nIHRhc2tzIHRvIGJlIHJ1biBvbiB0aGVcbnNhbWUgcmVzb3Vy
-        Y2UuIEl0IGFsc28gb3B0aW9uYWxseSBwcm92aWRlcyBEeW5mbG93IGluZnJh
-        c3RydWN0dXJlIGZvciB1c2luZyBpdCBmb3IgbWFuYWdpbmcgdGhlIHRhc2tz
-        LlxuIiwidXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL3RoZWZvcmVtYW4vZm9y
-        ZW1hbi10YXNrcyIsInZlcnNpb24iOiIwLjcuMTkifSx7ImlkIjoiZm9yZW1h
-        bl9kb2NrZXIiLCJuYW1lIjoiZm9yZW1hbl9kb2NrZXIiLCJhdXRob3IiOiJE
-        YW5pZWwgTG9iYXRvLCBBbW9zIEJlbmFyaSIsImRlc2NyaXB0aW9uIjoiUHJv
-        dmlzaW9uIGFuZCBtYW5hZ2UgRG9ja2VyIGNvbnRhaW5lcnMgYW5kIGltYWdl
-        cyBmcm9tIEZvcmVtYW4uIiwidXJsIjoiaHR0cDovL2dpdGh1Yi5jb20vdGhl
-        Zm9yZW1hbi9mb3JlbWFuLWRvY2tlciIsInZlcnNpb24iOiIyLjEuMSJ9LHsi
-        aWQiOiJmb3JlbWFuX3JlbW90ZV9leGVjdXRpb24iLCJuYW1lIjoiZm9yZW1h
-        bl9yZW1vdGVfZXhlY3V0aW9uIiwiYXV0aG9yIjoiRm9yZW1hbiBSZW1vdGUg
-        RXhlY3V0aW9uIHRlYW0iLCJkZXNjcmlwdGlvbiI6IkEgcGx1Z2luIGJyaW5n
-        aW5nIHJlbW90ZSBleGVjdXRpb24gdG8gdGhlIEZvcmVtYW4sIGNvbXBsZXRp
-        bmcgdGhlIGNvbmZpZyBtYW5hZ2VtZW50IGZ1bmN0aW9uYWxpdHkgd2l0aCBy
-        ZW1vdGUgbWFuYWdlbWVudCBmdW5jdGlvbmFsaXR5LiIsInVybCI6Imh0dHBz
-        Oi8vZ2l0aHViLmNvbS90aGVmb3JlbWFuL2ZvcmVtYW5fcmVtb3RlX2V4ZWN1
-        dGlvbiIsInZlcnNpb24iOiIxLjAuMCJ9LHsiaWQiOiJrYXRlbGxvIiwibmFt
-        ZSI6ImthdGVsbG8iLCJhdXRob3IiOiJOL0EiLCJkZXNjcmlwdGlvbiI6IkNv
-        bnRlbnQgYW5kIFN1YnNjcmlwdGlvbiBNYW5hZ2VtZW50IHBsdWdpbiBmb3Ig
-        Rm9yZW1hbiIsInVybCI6Imh0dHA6Ly93d3cua2F0ZWxsby5vcmciLCJ2ZXJz
-        aW9uIjoiMy4yLjAifV0KfQo=
-    http_version: 
-  recorded_at: Wed, 03 Aug 2016 18:37:04 GMT
-- request:
-    method: get
-    uri: http://admin:changeme@katello:3000/api/settings?search=name=%22idle_timeout%22
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      Foreman-Version:
-      - 1.13.0-develop
-      Foreman-Api-Version:
-      - '2'
-      Content-Type:
-      - application/json; charset=utf-8
-      Apipie-Checksum:
-      - e98945ba1db6bdbb4c25ce4988912344
-      Etag:
-      - W/"0ee4ceb7b718054a40fb49aa97ff9317"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Set-Cookie:
-      - _session_id=3382db5153910129bb1d083cd4e68421; path=/; HttpOnly
-      X-Request-Id:
-      - f16c1948-3419-4422-ae0a-eee9bafd7844
-      X-Runtime:
-      - '0.464199'
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-          "total": 104,
-          "subtotal": 1,
-          "page": 1,
-          "per_page": 20,
-          "search": "name=\"idle_timeout\"",
-          "sort": {
-            "by": null,
-            "order": null
-          },
-          "results": [{"value":60000,"description":"Log out idle users after a certain number of minutes","category":"Setting::Auth","settings_type":"integer","default":60,"created_at":"2016-07-15 13:17:56 UTC","updated_at":"2016-07-15 13:38:43 UTC","id":104,"name":"idle_timeout"}]
-        }
-    http_version: 
-  recorded_at: Wed, 03 Aug 2016 18:37:04 GMT
+  recorded_at: Tue, 23 Aug 2016 12:27:07 GMT
 - request:
     method: put
-    uri: http://admin:changeme@katello:3000/api/settings/104
+    uri: http://admin:changeme@katello:3000/api/settings/99
     body:
       encoding: UTF-8
       string: '{"setting":{"value":"60000"}}'
@@ -18754,23 +18810,23 @@ http_interactions:
       Apipie-Checksum:
       - e98945ba1db6bdbb4c25ce4988912344
       Etag:
-      - W/"fad2d243311537e4336d8fdd609f58db"
+      - W/"076d4507efa74eb8790faa1c97e1c713"
       Cache-Control:
       - max-age=0, private, must-revalidate
       Set-Cookie:
-      - _session_id=3bd66552dd1479004842de123877b27c; path=/; HttpOnly
+      - _session_id=77e996e0e83d5d521158c97d748ee59b; path=/; HttpOnly
       - request_method=PUT; path=/
       X-Request-Id:
-      - 22959f07-f544-4d77-bce4-54f9f908e55c
+      - 940fefbd-b49c-47dd-a68d-3e6ba2c7b040
       X-Runtime:
-      - '1.433806'
+      - '0.375763'
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: '{"value":60000,"description":"Log out idle users after a certain number
-        of minutes","category":"Setting::Auth","settings_type":"integer","default":60,"created_at":"2016-07-15
-        13:17:56 UTC","updated_at":"2016-07-15 13:38:43 UTC","id":104,"name":"idle_timeout"}'
+        of minutes","category":"Setting::Auth","settings_type":"integer","default":60,"created_at":"2016-08-10
+        12:38:11 UTC","updated_at":"2016-08-10 13:34:48 UTC","id":99,"name":"idle_timeout"}'
     http_version: 
-  recorded_at: Wed, 03 Aug 2016 18:37:06 GMT
+  recorded_at: Tue, 23 Aug 2016 12:27:07 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/resources/settings_import/update_settings_continue.yml
+++ b/test/fixtures/vcr_cassettes/resources/settings_import/update_settings_continue.yml
@@ -1,0 +1,316 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://admin:changeme@katello:3000/api/status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Foreman-Version:
+      - 1.13.0-develop
+      Foreman-Api-Version:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      Apipie-Checksum:
+      - e98945ba1db6bdbb4c25ce4988912344
+      Etag:
+      - W/"f536fd8685b76bb26a943d472593c93e"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Set-Cookie:
+      - _session_id=fe8e544a6960d4e9414c6c6f9485039d; path=/; HttpOnly
+      X-Request-Id:
+      - 382dfe53-746c-4d59-a1ad-6f23d903362b
+      X-Runtime:
+      - '0.219354'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"result":"ok","status":200,"version":"1.13.0-develop","api_version":2}'
+    http_version:
+  recorded_at: Tue, 23 Aug 2016 12:27:08 GMT
+- request:
+    method: get
+    uri: http://admin:changeme@katello:3000/api/v2/plugins
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Foreman-Version:
+      - 1.13.0-develop
+      Foreman-Api-Version:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      Apipie-Checksum:
+      - e98945ba1db6bdbb4c25ce4988912344
+      Etag:
+      - W/"5fdeea8a610f7805000b37060cecd4be"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Set-Cookie:
+      - _session_id=751cd08fdddca7c9e57a7fe911851ab7; path=/; HttpOnly
+      X-Request-Id:
+      - e084840e-5972-4d4a-8d86-04b3034325b2
+      X-Runtime:
+      - '0.224010'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJ0b3RhbCI6IDQsCiAgInN1YnRvdGFsIjogNCwKICAicGFnZSI6IDEs
+        CiAgInBlcl9wYWdlIjogMjAsCiAgInNlYXJjaCI6IG51bGwsCiAgInNvcnQi
+        OiB7CiAgICAiYnkiOiBudWxsLAogICAgIm9yZGVyIjogbnVsbAogIH0sCiAg
+        InJlc3VsdHMiOiBbeyJpZCI6ImZvcmVtYW4tdGFza3MiLCJuYW1lIjoiZm9y
+        ZW1hbi10YXNrcyIsImF1dGhvciI6Ikl2YW4gTmXEjWFzIiwiZGVzY3JpcHRp
+        b24iOiJUaGUgZ29hbCBvZiB0aGlzIHBsdWdpbiBpcyB0byB1bmlmeSB0aGUg
+        d2F5IG9mIHNob3dpbmcgdGFzayBzdGF0dXNlcyBhY3Jvc3MgdGhlIEZvcmVt
+        YW4gaW5zdGFuY2UuXG5JdCBkZWZpbmVzIFRhc2sgbW9kZWwgZm9yIGtlZXBp
+        bmcgdGhlIGluZm9ybWF0aW9uIGFib3V0IHRoZSB0YXNrcyBhbmQgTG9jayBm
+        b3IgYXNzaWduaW5nIHRoZSB0YXNrc1xudG8gcmVzb3VyY2VzLiBUaGUgbG9j
+        a2luZyBhbGxvd3MgZGVhbGluZyB3aXRoIHByZXZlbnRpbmcgbXVsdGlwbGUg
+        Y29sbGlkaW5nIHRhc2tzIHRvIGJlIHJ1biBvbiB0aGVcbnNhbWUgcmVzb3Vy
+        Y2UuIEl0IGFsc28gb3B0aW9uYWxseSBwcm92aWRlcyBEeW5mbG93IGluZnJh
+        c3RydWN0dXJlIGZvciB1c2luZyBpdCBmb3IgbWFuYWdpbmcgdGhlIHRhc2tz
+        LlxuIiwidXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL3RoZWZvcmVtYW4vZm9y
+        ZW1hbi10YXNrcyIsInZlcnNpb24iOiIwLjguMCJ9LHsiaWQiOiJmb3JlbWFu
+        X2RvY2tlciIsIm5hbWUiOiJmb3JlbWFuX2RvY2tlciIsImF1dGhvciI6IkRh
+        bmllbCBMb2JhdG8sIEFtb3MgQmVuYXJpIiwiZGVzY3JpcHRpb24iOiJQcm92
+        aXNpb24gYW5kIG1hbmFnZSBEb2NrZXIgY29udGFpbmVycyBhbmQgaW1hZ2Vz
+        IGZyb20gRm9yZW1hbi4iLCJ1cmwiOiJodHRwOi8vZ2l0aHViLmNvbS90aGVm
+        b3JlbWFuL2ZvcmVtYW4tZG9ja2VyIiwidmVyc2lvbiI6IjMuMC4wIn0seyJp
+        ZCI6ImZvcmVtYW5fcmVtb3RlX2V4ZWN1dGlvbiIsIm5hbWUiOiJmb3JlbWFu
+        X3JlbW90ZV9leGVjdXRpb24iLCJhdXRob3IiOiJGb3JlbWFuIFJlbW90ZSBF
+        eGVjdXRpb24gdGVhbSIsImRlc2NyaXB0aW9uIjoiQSBwbHVnaW4gYnJpbmdp
+        bmcgcmVtb3RlIGV4ZWN1dGlvbiB0byB0aGUgRm9yZW1hbiwgY29tcGxldGlu
+        ZyB0aGUgY29uZmlnIG1hbmFnZW1lbnQgZnVuY3Rpb25hbGl0eSB3aXRoIHJl
+        bW90ZSBtYW5hZ2VtZW50IGZ1bmN0aW9uYWxpdHkuIiwidXJsIjoiaHR0cHM6
+        Ly9naXRodWIuY29tL3RoZWZvcmVtYW4vZm9yZW1hbl9yZW1vdGVfZXhlY3V0
+        aW9uIiwidmVyc2lvbiI6IjEuMC4wIn0seyJpZCI6ImthdGVsbG8iLCJuYW1l
+        Ijoia2F0ZWxsbyIsImF1dGhvciI6Ik4vQSIsImRlc2NyaXB0aW9uIjoiQ29u
+        dGVudCBhbmQgU3Vic2NyaXB0aW9uIE1hbmFnZW1lbnQgcGx1Z2luIGZvciBG
+        b3JlbWFuIiwidXJsIjoiaHR0cDovL3d3dy5rYXRlbGxvLm9yZyIsInZlcnNp
+        b24iOiIzLjIuMCJ9XQp9Cg==
+    http_version:
+  recorded_at: Tue, 23 Aug 2016 12:27:08 GMT
+- request:
+    method: get
+    uri: http://admin:changeme@katello:3000/api/settings?search=name=%22badsetting%22
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Foreman-Version:
+      - 1.13.0-develop
+      Foreman-Api-Version:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      Apipie-Checksum:
+      - e98945ba1db6bdbb4c25ce4988912344
+      Etag:
+      - W/"d4c516d8c44e3fc286dd84616988bd22"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Set-Cookie:
+      - _session_id=b099cb53a190d8eeb8145a91bd76a1e5; path=/; HttpOnly
+      X-Request-Id:
+      - 89dce3ed-ef29-4b22-a4ce-1a51ebb3e8c1
+      X-Runtime:
+      - '0.241582'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "total": 106,
+          "subtotal": 0,
+          "page": 1,
+          "per_page": 20,
+          "search": "name=\"badsetting\"",
+          "sort": {
+            "by": null,
+            "order": null
+          },
+          "results": []
+        }
+    http_version:
+  recorded_at: Tue, 23 Aug 2016 12:27:08 GMT
+- request:
+    method: get
+    uri: http://admin:changeme@katello:3000/api/settings?search=name=%22idle_timeout%22
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Foreman-Version:
+      - 1.13.0-develop
+      Foreman-Api-Version:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      Apipie-Checksum:
+      - e98945ba1db6bdbb4c25ce4988912344
+      Etag:
+      - W/"36e0831745e01f3460c82a79d66680fb"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Set-Cookie:
+      - _session_id=808587226a38c5127d61e77e36a05692; path=/; HttpOnly
+      X-Request-Id:
+      - 7820d6c0-a37e-4fdd-a2c1-ba16669133e0
+      X-Runtime:
+      - '0.303437'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "total": 106,
+          "subtotal": 1,
+          "page": 1,
+          "per_page": 20,
+          "search": "name=\"idle_timeout\"",
+          "sort": {
+            "by": null,
+            "order": null
+          },
+          "results": [{"value":60000,"description":"Log out idle users after a certain number of minutes","category":"Setting::Auth","settings_type":"integer","default":60,"created_at":"2016-08-10 12:38:11 UTC","updated_at":"2016-08-10 13:34:48 UTC","id":99,"name":"idle_timeout"}]
+        }
+    http_version:
+  recorded_at: Tue, 23 Aug 2016 12:27:08 GMT
+- request:
+    method: put
+    uri: http://admin:changeme@katello:3000/api/settings/99
+    body:
+      encoding: UTF-8
+      string: '{"setting":{"value":"60000"}}'
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '29'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Foreman-Version:
+      - 1.13.0-develop
+      Foreman-Api-Version:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      Apipie-Checksum:
+      - e98945ba1db6bdbb4c25ce4988912344
+      Etag:
+      - W/"076d4507efa74eb8790faa1c97e1c713"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Set-Cookie:
+      - _session_id=2db127278d1d58e8edacf000b8807c04; path=/; HttpOnly
+      - request_method=PUT; path=/
+      X-Request-Id:
+      - 9f7e6bbd-61d7-45d7-9bb6-73875ebb50d1
+      X-Runtime:
+      - '0.322533'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"value":60000,"description":"Log out idle users after a certain number
+        of minutes","category":"Setting::Auth","settings_type":"integer","default":60,"created_at":"2016-08-10
+        12:38:11 UTC","updated_at":"2016-08-10 13:34:48 UTC","id":99,"name":"idle_timeout"}'
+    http_version:
+  recorded_at: Tue, 23 Aug 2016 12:27:09 GMT
+recorded_with: VCR 3.0.3

--- a/test/resources/content_hosts_test.rb
+++ b/test/resources/content_hosts_test.rb
@@ -16,6 +16,7 @@ Usage:
      csv content-hosts [OPTIONS]
 
 Options:
+ --continue-on-error           Continue processing even if individual resource error
  --export                      Export current data instead of importing
  --file FILE_NAME              CSV file (default to /dev/stdout with --export, otherwise required)
  --organization ORGANIZATION   Only process organization matching this name

--- a/test/resources/settings_test.rb
+++ b/test/resources/settings_test.rb
@@ -16,6 +16,7 @@ Usage:
      csv settings [OPTIONS]
 
 Options:
+ --continue-on-error           Continue processing even if individual resource error
  --export                      Export current data instead of importing
  --file FILE_NAME              CSV file (default to /dev/stdout with --export, otherwise required)
  --organization ORGANIZATION   Only process organization matching this name
@@ -47,6 +48,31 @@ FILE
       stderr.must_equal ''
       lines = stdout.split("\n")
       assert_equal "Updating setting 'idle_timeout'...done", lines[0]
+      file.unlink
+      stop_vcr
+    end
+
+    def test_update_settings_continue
+      start_vcr
+      set_user 'admin'
+
+      name = "settings#{rand(10000)}"
+
+      file = Tempfile.new('settings_test')
+      # rubocop:disable LineLength
+      file.write <<-FILE
+Name,Count,Value
+badsetting,1,1234
+idle_timeout,1,60000
+FILE
+      file.rewind
+
+      stdout,stderr = capture {
+        hammer.run(%W{csv settings --verbose --continue-on-error --file #{file.path}})
+      }
+      stderr.must_equal "Error: Setting 'badsetting' not found\nbadsetting,1,1234\n"
+      lines = stdout.split("\n")
+      assert_equal lines[0], "Updating setting 'idle_timeout'...done"
       file.unlink
       stop_vcr
     end

--- a/test/resources/subscriptions_test.rb
+++ b/test/resources/subscriptions_test.rb
@@ -16,6 +16,7 @@ Usage:
      csv subscriptions [OPTIONS]
 
 Options:
+ --continue-on-error           Continue processing even if individual resource error
  --export                      Export current data instead of importing
  --file FILE_NAME              CSV file (default to /dev/stdout with --export, otherwise required)
  --organization ORGANIZATION   Only process organization matching this name


### PR DESCRIPTION
Previously when an error would occur, either on import or export of a row of CSV, the run would abort. With the option --continue-on-error the run will continue.