### PR TITLE
Fixes #17307 - move help module out of CsvCommand

### DIFF
--- a/lib/hammer_cli_csv/csv.rb
+++ b/lib/hammer_cli_csv/csv.rb
@@ -2,24 +2,24 @@ require 'hammer_cli'
 require 'hammer_cli/exit_codes'
 
 module HammerCLICsv
+  module Help
+    class Builder < HammerCLI::Help::Builder
+      def add_list(heading, items)
+        items.delete_if do |item|
+          if item.class == Clamp::Subcommand::Definition
+            !item.subcommand_class.supported?
+          else
+            false
+          end
+        end
+        super(heading, items)
+      end
+    end
+  end
+
   class CsvCommand < HammerCLI::AbstractCommand
     def help
       self.class.help(invocation_path, HammerCLICsv::Help::Builder.new)
-    end
-
-    module Help
-      class Builder < HammerCLI::Help::Builder
-        def add_list(heading, items)
-          items.delete_if do |item|
-            if item.class == Clamp::Subcommand::Definition
-              !item.subcommand_class.supported?
-            else
-              false
-            end
-          end
-          super(heading, items)
-        end
-      end
     end
   end
 


### PR DESCRIPTION
Test with a simple `hammer csv -h`