### PR TITLE
Fix content-host export organizations

### DIFF
--- a/lib/hammer_cli_csv/content_hosts.rb
+++ b/lib/hammer_cli_csv/content_hosts.rb
@@ -452,10 +452,9 @@ module HammerCLICsv
       def iterate_hosts(csv)
         hypervisors = []
         hosts = []
-        @api.resource(:organizations).call(:index, {
-            'full_results' => true
-        })['results'].each do |organization|
-          next if option_organization && organization['name'] != option_organization
+        organization_search_options = {:per_page => 999999}
+        organization_search_options['search'] = "name=\"#{option_organization}\"" if option_organization
+        @api.resource(:organizations).call(:index, organization_search_options)['results'].each do |organization|
 
           total = @api.resource(:hosts).call(:index, {
               'organization_id' => foreman_organization(:name => organization['name']),

--- a/test/fixtures/vcr_cassettes/resources/content_hosts/columns_config.yml
+++ b/test/fixtures/vcr_cassettes/resources/content_hosts/columns_config.yml
@@ -20337,6 +20337,83 @@ http_interactions:
           },
           "results": [{"label":"testcorp","created_at":"2016-12-01 19:35:26 UTC","updated_at":"2017-03-27 18:36:51 UTC","id":3,"name":"Test Corporation","title":"Test Corporation","description":"Testing today for a better tomorrow"}]
         }
+    http_version:
+  recorded_at: Thu, 06 Apr 2017 01:37:33 GMT
+- request:
+    method: get
+    uri: https://admin:changeme@devel.example.com:50083/katello/api/organizations?per_page=999999&search=name=%22Test%20Corporation%22
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      Content-Type:
+      - application/json
+      Accept-Language:
+      - en
+      Host:
+      - devel.example.com:50083
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 06 Apr 2017 01:37:22 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Foreman-Version:
+      - 1.11.0.54
+      Foreman-Api-Version:
+      - '2'
+      Apipie-Checksum:
+      - e1df2e8d43e22495b02a53b48e3b5298
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 1780a474-ea23-47b2-9c06-7cfcff957591
+      X-Runtime:
+      - '0.057967'
+      X-Powered-By:
+      - Phusion Passenger 4.0.18
+      Etag:
+      - '"442ba11ec0703ed2d5c48129111cd2c5-gzip"'
+      Status:
+      - 200 OK
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '388'
+      Content-Type:
+      - application/json; charset=utf-8
+      Set-Cookie:
+      - _session_id=3e67291d20735ca8f2cb4a97711e8952; path=/; secure; HttpOnly
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "total": 2,
+          "subtotal": 1,
+          "page": 1,
+          "per_page": 999999,
+          "search": "name=\"Test Corporation\"",
+          "sort": {
+            "by": null,
+            "order": null
+          },
+          "results": [{"label":"testcorp","created_at":"2016-12-01 19:35:26 UTC","updated_at":"2017-03-27 18:36:51 UTC","id":3,"name":"Test Corporation","title":"Test Corporation","description":"Testing today for a better tomorrow"}]
+        }
     http_version: 
   recorded_at: Thu, 06 Apr 2017 01:37:33 GMT
 - request:

--- a/test/fixtures/vcr_cassettes/resources/content_hosts/columns_config_options.yml
+++ b/test/fixtures/vcr_cassettes/resources/content_hosts/columns_config_options.yml
@@ -20493,6 +20493,83 @@ http_interactions:
   recorded_at: Thu, 06 Apr 2017 01:38:26 GMT
 - request:
     method: get
+    uri: https://admin:changeme@devel.example.com:50083/katello/api/organizations?per_page=999999&search=name=%22Test%20Corporation%22
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      Content-Type:
+      - application/json
+      Accept-Language:
+      - en
+      Host:
+      - devel.example.com:50083
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 06 Apr 2017 01:38:15 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Foreman-Version:
+      - 1.11.0.54
+      Foreman-Api-Version:
+      - '2'
+      Apipie-Checksum:
+      - e1df2e8d43e22495b02a53b48e3b5298
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 847c9d02-28c3-4a87-bf68-698f0a247d8f
+      X-Runtime:
+      - '0.045288'
+      X-Powered-By:
+      - Phusion Passenger 4.0.18
+      Etag:
+      - '"442ba11ec0703ed2d5c48129111cd2c5-gzip"'
+      Status:
+      - 200 OK
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '388'
+      Content-Type:
+      - application/json; charset=utf-8
+      Set-Cookie:
+      - _session_id=48264994f8a88ce6ca88fb4075a542b3; path=/; secure; HttpOnly
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "total": 2,
+          "subtotal": 1,
+          "page": 1,
+          "per_page": 999999,
+          "search": "name=\"Test Corporation\"",
+          "sort": {
+            "by": null,
+            "order": null
+          },
+          "results": [{"label":"testcorp","created_at":"2016-12-01 19:35:26 UTC","updated_at":"2017-03-27 18:36:51 UTC","id":3,"name":"Test Corporation","title":"Test Corporation","description":"Testing today for a better tomorrow"}]
+        }
+    http_version:
+  recorded_at: Thu, 06 Apr 2017 01:38:26 GMT
+- request:
+    method: get
     uri: https://admin:changeme@devel.example.com:50083/katello/api/organizations?full_results=true
     body:
       encoding: US-ASCII
@@ -20643,7 +20720,84 @@ http_interactions:
           },
           "results": [{"label":"testcorp","created_at":"2016-12-01 19:35:26 UTC","updated_at":"2017-03-27 18:36:51 UTC","id":3,"name":"Test Corporation","title":"Test Corporation","description":"Testing today for a better tomorrow"}]
         }
-    http_version: 
+    http_version:
+  recorded_at: Thu, 06 Apr 2017 01:38:26 GMT
+- request:
+    method: get
+    uri: https://admin:changeme@devel.example.com:50083/katello/api/organizations?per_page=999999&search=name=%22Test%20Corporation%22
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      Content-Type:
+      - application/json
+      Accept-Language:
+      - en
+      Host:
+      - devel.example.com:50083
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 06 Apr 2017 01:38:15 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Foreman-Version:
+      - 1.11.0.54
+      Foreman-Api-Version:
+      - '2'
+      Apipie-Checksum:
+      - e1df2e8d43e22495b02a53b48e3b5298
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 847c9d02-28c3-4a87-bf68-698f0a247d8f
+      X-Runtime:
+      - '0.045288'
+      X-Powered-By:
+      - Phusion Passenger 4.0.18
+      Etag:
+      - '"442ba11ec0703ed2d5c48129111cd2c5-gzip"'
+      Status:
+      - 200 OK
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '388'
+      Content-Type:
+      - application/json; charset=utf-8
+      Set-Cookie:
+      - _session_id=48264994f8a88ce6ca88fb4075a542b3; path=/; secure; HttpOnly
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "total": 2,
+          "subtotal": 1,
+          "page": 1,
+          "per_page": 999999,
+          "search": "name=\"Test Corporation\"",
+          "sort": {
+            "by": null,
+            "order": null
+          },
+          "results": [{"label":"testcorp","created_at":"2016-12-01 19:35:26 UTC","updated_at":"2017-03-27 18:36:51 UTC","id":3,"name":"Test Corporation","title":"Test Corporation","description":"Testing today for a better tomorrow"}]
+        }
+    http_version:
   recorded_at: Thu, 06 Apr 2017 01:38:26 GMT
 - request:
     method: get

--- a/test/fixtures/vcr_cassettes/resources/content_hosts/columns_options.yml
+++ b/test/fixtures/vcr_cassettes/resources/content_hosts/columns_options.yml
@@ -21982,6 +21982,83 @@ http_interactions:
           },
           "results": [{"label":"testcorp","created_at":"2016-12-01 19:35:26 UTC","updated_at":"2017-03-27 18:36:51 UTC","id":3,"name":"Test Corporation","title":"Test Corporation","description":"Testing today for a better tomorrow"}]
         }
+    http_version:
+  recorded_at: Thu, 06 Apr 2017 01:37:03 GMT
+- request:
+    method: get
+    uri: https://admin:changeme@devel.example.com:50083/katello/api/organizations?per_page=999999&search=name=%22Test%20Corporation%22
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      Content-Type:
+      - application/json
+      Accept-Language:
+      - en
+      Host:
+      - devel.example.com:50083
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 06 Apr 2017 01:36:51 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Foreman-Version:
+      - 1.11.0.54
+      Foreman-Api-Version:
+      - '2'
+      Apipie-Checksum:
+      - e1df2e8d43e22495b02a53b48e3b5298
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - ed005218-dc1f-4df2-b0b5-764f7f8db207
+      X-Runtime:
+      - '0.077668'
+      X-Powered-By:
+      - Phusion Passenger 4.0.18
+      Etag:
+      - '"442ba11ec0703ed2d5c48129111cd2c5-gzip"'
+      Status:
+      - 200 OK
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '388'
+      Content-Type:
+      - application/json; charset=utf-8
+      Set-Cookie:
+      - _session_id=2951569f09136c02bd43604e110eb2d8; path=/; secure; HttpOnly
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "total": 2,
+          "subtotal": 1,
+          "page": 1,
+          "per_page": 999999,
+          "search": "name=\"Test Corporation\"",
+          "sort": {
+            "by": null,
+            "order": null
+          },
+          "results": [{"label":"testcorp","created_at":"2016-12-01 19:35:26 UTC","updated_at":"2017-03-27 18:36:51 UTC","id":3,"name":"Test Corporation","title":"Test Corporation","description":"Testing today for a better tomorrow"}]
+        }
     http_version: 
   recorded_at: Thu, 06 Apr 2017 01:37:03 GMT
 - request:

--- a/test/fixtures/vcr_cassettes/resources/content_hosts/export.yml
+++ b/test/fixtures/vcr_cassettes/resources/content_hosts/export.yml
@@ -20475,7 +20475,84 @@ http_interactions:
           },
           "results": [{"label":"testcorp","created_at":"2016-12-01 19:35:26 UTC","updated_at":"2017-03-27 18:36:51 UTC","id":3,"name":"Test Corporation","title":"Test Corporation","description":"Testing today for a better tomorrow"}]
         }
-    http_version: 
+    http_version:
+  recorded_at: Thu, 06 Apr 2017 01:37:35 GMT
+- request:
+    method: get
+    uri: https://admin:changeme@devel.example.com:50083/katello/api/organizations?per_page=999999&search=name=%22Test%20Corporation%22
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      Content-Type:
+      - application/json
+      Accept-Language:
+      - en
+      Host:
+      - devel.example.com:50083
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 06 Apr 2017 01:37:24 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Foreman-Version:
+      - 1.11.0.54
+      Foreman-Api-Version:
+      - '2'
+      Apipie-Checksum:
+      - e1df2e8d43e22495b02a53b48e3b5298
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 6c0033e1-a9cf-4da7-9e1c-e561a095220d
+      X-Runtime:
+      - '0.055515'
+      X-Powered-By:
+      - Phusion Passenger 4.0.18
+      Etag:
+      - '"442ba11ec0703ed2d5c48129111cd2c5-gzip"'
+      Status:
+      - 200 OK
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '388'
+      Content-Type:
+      - application/json; charset=utf-8
+      Set-Cookie:
+      - _session_id=de42b79eb6f1f33c2b5f3acc806366b0; path=/; secure; HttpOnly
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "total": 2,
+          "subtotal": 1,
+          "page": 1,
+          "per_page": 999999,
+          "search": "name=\"Test Corporation\"",
+          "sort": {
+            "by": null,
+            "order": null
+          },
+          "results": [{"label":"testcorp","created_at":"2016-12-01 19:35:26 UTC","updated_at":"2017-03-27 18:36:51 UTC","id":3,"name":"Test Corporation","title":"Test Corporation","description":"Testing today for a better tomorrow"}]
+        }
+    http_version:
   recorded_at: Thu, 06 Apr 2017 01:37:35 GMT
 - request:
     method: get

--- a/test/fixtures/vcr_cassettes/resources/content_hosts/export_subscriptions.yml
+++ b/test/fixtures/vcr_cassettes/resources/content_hosts/export_subscriptions.yml
@@ -20475,6 +20475,83 @@ http_interactions:
           },
           "results": [{"label":"testcorp","created_at":"2016-12-01 19:35:26 UTC","updated_at":"2017-03-27 18:36:51 UTC","id":3,"name":"Test Corporation","title":"Test Corporation","description":"Testing today for a better tomorrow"}]
         }
+    http_version:
+  recorded_at: Thu, 06 Apr 2017 01:36:56 GMT
+- request:
+    method: get
+    uri: https://admin:changeme@devel.example.com:50083/katello/api/organizations?per_page=999999&search=name=%22Test%20Corporation%22
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      Content-Type:
+      - application/json
+      Accept-Language:
+      - en
+      Host:
+      - devel.example.com:50083
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 06 Apr 2017 01:36:45 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Foreman-Version:
+      - 1.11.0.54
+      Foreman-Api-Version:
+      - '2'
+      Apipie-Checksum:
+      - e1df2e8d43e22495b02a53b48e3b5298
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 2a32b95b-9b25-427c-b36a-f8046a63b743
+      X-Runtime:
+      - '0.055781'
+      X-Powered-By:
+      - Phusion Passenger 4.0.18
+      Etag:
+      - '"442ba11ec0703ed2d5c48129111cd2c5-gzip"'
+      Status:
+      - 200 OK
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '388'
+      Content-Type:
+      - application/json; charset=utf-8
+      Set-Cookie:
+      - _session_id=d67cd9f73f9fec04c0808f6d83d48f01; path=/; secure; HttpOnly
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "total": 2,
+          "subtotal": 1,
+          "page": 1,
+          "per_page": 999999,
+          "search": "name=\"Test Corporation\"",
+          "sort": {
+            "by": null,
+            "order": null
+          },
+          "results": [{"label":"testcorp","created_at":"2016-12-01 19:35:26 UTC","updated_at":"2017-03-27 18:36:51 UTC","id":3,"name":"Test Corporation","title":"Test Corporation","description":"Testing today for a better tomorrow"}]
+        }
     http_version: 
   recorded_at: Thu, 06 Apr 2017 01:36:56 GMT
 - request:

--- a/test/fixtures/vcr_cassettes/resources/content_hosts/hypervisor_prefix.yml
+++ b/test/fixtures/vcr_cassettes/resources/content_hosts/hypervisor_prefix.yml
@@ -23098,4 +23098,81 @@ http_interactions:
       string: '{"id":316,"name":"abcprefixguest","last_compile":"2017-04-06T01:37:16.000Z","last_report":null,"updated_at":"2017-04-06T01:37:16.838Z","created_at":"2017-04-06T01:37:14.694Z","root_pass":null,"architecture_id":null,"operatingsystem_id":null,"environment_id":null,"ptable_id":null,"medium_id":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":3,"owner_type":"User","enabled":true,"puppet_ca_proxy_id":null,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"puppet_proxy_id":null,"certname":"abcprefixguest","image_id":null,"organization_id":3,"location_id":2,"otp":null,"realm_id":null,"compute_profile_id":null,"provision_method":"build","content_source_id":null,"grub_pass":"","discovery_rule_id":null,"content_view_id":null,"lifecycle_environment_id":null,"global_status":0,"lookup_value_matcher":"fqdn=abcprefixguest","openscap_proxy_id":null,"content_facet_attributes":{"id":315,"host_id":316,"uuid":"d8d0cdb0-205f-4bd8-a24c-3df39875aa45","content_view_id":2,"lifecycle_environment_id":2,"kickstart_repository_id":null},"subscription_facet_attributes":{"id":321,"host_id":316,"uuid":"d8d0cdb0-205f-4bd8-a24c-3df39875aa45","last_checkin":"2017-04-06T01:37:14.714Z","service_level":null,"release_version":null,"autoheal":true,"registered_at":"2017-04-06T01:37:14.888Z"}}'
     http_version: 
   recorded_at: Thu, 06 Apr 2017 01:37:33 GMT
+- request:
+    method: get
+    uri: https://admin:changeme@devel.example.com:50083/katello/api/organizations?per_page=999999&search=name=%22Test%20Corporation%22
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      Content-Type:
+      - application/json
+      Accept-Language:
+      - en
+      Host:
+      - devel.example.com:50083
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 06 Apr 2017 01:37:23 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Foreman-Version:
+      - 1.11.0.54
+      Foreman-Api-Version:
+      - '2'
+      Apipie-Checksum:
+      - e1df2e8d43e22495b02a53b48e3b5298
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - df26776e-48fc-4b7c-adb3-898a48a3ad2a
+      X-Runtime:
+      - '0.072164'
+      X-Powered-By:
+      - Phusion Passenger 4.0.18
+      Etag:
+      - '"ffee47ad15c7fec31c37fd0e7c1971eb-gzip"'
+      Status:
+      - 200 OK
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '388'
+      Content-Type:
+      - application/json; charset=utf-8
+      Set-Cookie:
+      - _session_id=818014e4577176053051f3955b72aa45; path=/; secure; HttpOnly
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "total": 2,
+          "subtotal": 1,
+          "page": 1,
+          "per_page": 999999,
+          "search": "name=\"Test Corporation\"",
+          "sort": {
+            "by": null,
+            "order": null
+          },
+          "results": [{"label":"testcorp","created_at":"2016-12-01 19:35:26 UTC","updated_at":"2017-03-27 18:36:51 UTC","id":3,"name":"Test Corporation","title":"Test Corporation","description":"Testing today for a better tomorrow"}]
+        }
+    http_version:
+  recorded_at: Thu, 06 Apr 2017 01:37:35 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/resources/content_hosts/import_single_line.yml
+++ b/test/fixtures/vcr_cassettes/resources/content_hosts/import_single_line.yml
@@ -22876,6 +22876,83 @@ http_interactions:
       message: OK
     headers:
       Date:
+      - Thu, 06 Apr 2017 01:37:23 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Foreman-Version:
+      - 1.11.0.54
+      Foreman-Api-Version:
+      - '2'
+      Apipie-Checksum:
+      - e1df2e8d43e22495b02a53b48e3b5298
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - df26776e-48fc-4b7c-adb3-898a48a3ad2a
+      X-Runtime:
+      - '0.072164'
+      X-Powered-By:
+      - Phusion Passenger 4.0.18
+      Etag:
+      - '"ffee47ad15c7fec31c37fd0e7c1971eb-gzip"'
+      Status:
+      - 200 OK
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '388'
+      Content-Type:
+      - application/json; charset=utf-8
+      Set-Cookie:
+      - _session_id=818014e4577176053051f3955b72aa45; path=/; secure; HttpOnly
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "total": 2,
+          "subtotal": 1,
+          "page": 1,
+          "per_page": 999999,
+          "search": "name=\"Test Corporation\"",
+          "sort": {
+            "by": null,
+            "order": null
+          },
+          "results": [{"label":"testcorp","created_at":"2016-12-01 19:35:26 UTC","updated_at":"2017-03-27 18:36:51 UTC","id":3,"name":"Test Corporation","title":"Test Corporation","description":"Testing today for a better tomorrow"}]
+        }
+    http_version:
+  recorded_at: Thu, 06 Apr 2017 01:37:35 GMT
+- request:
+    method: get
+    uri: https://admin:changeme@devel.example.com:50083/katello/api/organizations?per_page=999999&search=name=%22Test%20Corporation%22
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      Content-Type:
+      - application/json
+      Accept-Language:
+      - en
+      Host:
+      - devel.example.com:50083
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
       - Thu, 06 Apr 2017 01:37:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
@@ -22926,7 +23003,7 @@ http_interactions:
           },
           "results": [{"label":"testcorp","created_at":"2016-12-01 19:35:26 UTC","updated_at":"2017-03-27 18:36:51 UTC","id":3,"name":"Test Corporation","title":"Test Corporation","description":"Testing today for a better tomorrow"}]
         }
-    http_version: 
+    http_version:
   recorded_at: Thu, 06 Apr 2017 01:37:18 GMT
 - request:
     method: get

--- a/test/fixtures/vcr_cassettes/resources/content_hosts/import_single_line_clear_subs.yml
+++ b/test/fixtures/vcr_cassettes/resources/content_hosts/import_single_line_clear_subs.yml
@@ -19904,6 +19904,83 @@ http_interactions:
       message: OK
     headers:
       Date:
+      - Thu, 06 Apr 2017 01:37:23 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Foreman-Version:
+      - 1.11.0.54
+      Foreman-Api-Version:
+      - '2'
+      Apipie-Checksum:
+      - e1df2e8d43e22495b02a53b48e3b5298
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - df26776e-48fc-4b7c-adb3-898a48a3ad2a
+      X-Runtime:
+      - '0.072164'
+      X-Powered-By:
+      - Phusion Passenger 4.0.18
+      Etag:
+      - '"ffee47ad15c7fec31c37fd0e7c1971eb-gzip"'
+      Status:
+      - 200 OK
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '388'
+      Content-Type:
+      - application/json; charset=utf-8
+      Set-Cookie:
+      - _session_id=818014e4577176053051f3955b72aa45; path=/; secure; HttpOnly
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "total": 2,
+          "subtotal": 1,
+          "page": 1,
+          "per_page": 999999,
+          "search": "name=\"Test Corporation\"",
+          "sort": {
+            "by": null,
+            "order": null
+          },
+          "results": [{"label":"testcorp","created_at":"2016-12-01 19:35:26 UTC","updated_at":"2017-03-27 18:36:51 UTC","id":3,"name":"Test Corporation","title":"Test Corporation","description":"Testing today for a better tomorrow"}]
+        }
+    http_version:
+  recorded_at: Thu, 06 Apr 2017 01:37:35 GMT
+- request:
+    method: get
+    uri: https://admin:changeme@devel.example.com:50083/katello/api/organizations?per_page=999999&search=name=%22Test%20Corporation%22
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      Content-Type:
+      - application/json
+      Accept-Language:
+      - en
+      Host:
+      - devel.example.com:50083
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
       - Thu, 06 Apr 2017 01:38:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)

--- a/test/fixtures/vcr_cassettes/resources/content_hosts/itemized_columns_config_options.yml
+++ b/test/fixtures/vcr_cassettes/resources/content_hosts/itemized_columns_config_options.yml
@@ -20769,6 +20769,160 @@ http_interactions:
   recorded_at: Thu, 06 Apr 2017 01:36:58 GMT
 - request:
     method: get
+    uri: https://admin:changeme@devel.example.com:50083/katello/api/organizations?per_page=999999&search=name=%22Test%20Corporation%22
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      Content-Type:
+      - application/json
+      Accept-Language:
+      - en
+      Host:
+      - devel.example.com:50083
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 06 Apr 2017 01:36:47 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Foreman-Version:
+      - 1.11.0.54
+      Foreman-Api-Version:
+      - '2'
+      Apipie-Checksum:
+      - e1df2e8d43e22495b02a53b48e3b5298
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 4e3ae29a-1a1e-44e8-8516-810f1e2725c3
+      X-Runtime:
+      - '0.069627'
+      X-Powered-By:
+      - Phusion Passenger 4.0.18
+      Etag:
+      - '"442ba11ec0703ed2d5c48129111cd2c5-gzip"'
+      Status:
+      - 200 OK
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '388'
+      Content-Type:
+      - application/json; charset=utf-8
+      Set-Cookie:
+      - _session_id=82c10f4410743b63feb86ea2a976bbcb; path=/; secure; HttpOnly
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "total": 2,
+          "subtotal": 1,
+          "page": 1,
+          "per_page": 999999,
+          "search": "name=\"Test Corporation\"",
+          "sort": {
+            "by": null,
+            "order": null
+          },
+          "results": [{"label":"testcorp","created_at":"2016-12-01 19:35:26 UTC","updated_at":"2017-03-27 18:36:51 UTC","id":3,"name":"Test Corporation","title":"Test Corporation","description":"Testing today for a better tomorrow"}]
+        }
+    http_version:
+  recorded_at: Thu, 06 Apr 2017 01:36:58 GMT
+- request:
+    method: get
+    uri: https://admin:changeme@devel.example.com:50083/katello/api/organizations?per_page=999999&search=name=%22Test%20Corporation%22
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      Content-Type:
+      - application/json
+      Accept-Language:
+      - en
+      Host:
+      - devel.example.com:50083
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 06 Apr 2017 01:36:47 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Foreman-Version:
+      - 1.11.0.54
+      Foreman-Api-Version:
+      - '2'
+      Apipie-Checksum:
+      - e1df2e8d43e22495b02a53b48e3b5298
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 4e3ae29a-1a1e-44e8-8516-810f1e2725c3
+      X-Runtime:
+      - '0.069627'
+      X-Powered-By:
+      - Phusion Passenger 4.0.18
+      Etag:
+      - '"442ba11ec0703ed2d5c48129111cd2c5-gzip"'
+      Status:
+      - 200 OK
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '388'
+      Content-Type:
+      - application/json; charset=utf-8
+      Set-Cookie:
+      - _session_id=82c10f4410743b63feb86ea2a976bbcb; path=/; secure; HttpOnly
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "total": 2,
+          "subtotal": 1,
+          "page": 1,
+          "per_page": 999999,
+          "search": "name=\"Test Corporation\"",
+          "sort": {
+            "by": null,
+            "order": null
+          },
+          "results": [{"label":"testcorp","created_at":"2016-12-01 19:35:26 UTC","updated_at":"2017-03-27 18:36:51 UTC","id":3,"name":"Test Corporation","title":"Test Corporation","description":"Testing today for a better tomorrow"}]
+        }
+    http_version:
+  recorded_at: Thu, 06 Apr 2017 01:36:58 GMT
+- request:
+    method: get
     uri: https://admin:changeme@devel.example.com:50083/katello/api/organizations?full_results=true
     body:
       encoding: US-ASCII
@@ -20919,7 +21073,7 @@ http_interactions:
           },
           "results": [{"label":"testcorp","created_at":"2016-12-01 19:35:26 UTC","updated_at":"2017-03-27 18:36:51 UTC","id":3,"name":"Test Corporation","title":"Test Corporation","description":"Testing today for a better tomorrow"}]
         }
-    http_version: 
+    http_version:
   recorded_at: Thu, 06 Apr 2017 01:36:58 GMT
 - request:
     method: get

--- a/test/fixtures/vcr_cassettes/resources/content_hosts/itemized_columns_options.yml
+++ b/test/fixtures/vcr_cassettes/resources/content_hosts/itemized_columns_options.yml
@@ -20425,6 +20425,83 @@ http_interactions:
       message: OK
     headers:
       Date:
+      - Thu, 06 Apr 2017 01:37:23 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Foreman-Version:
+      - 1.11.0.54
+      Foreman-Api-Version:
+      - '2'
+      Apipie-Checksum:
+      - e1df2e8d43e22495b02a53b48e3b5298
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - df26776e-48fc-4b7c-adb3-898a48a3ad2a
+      X-Runtime:
+      - '0.072164'
+      X-Powered-By:
+      - Phusion Passenger 4.0.18
+      Etag:
+      - '"ffee47ad15c7fec31c37fd0e7c1971eb-gzip"'
+      Status:
+      - 200 OK
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '388'
+      Content-Type:
+      - application/json; charset=utf-8
+      Set-Cookie:
+      - _session_id=818014e4577176053051f3955b72aa45; path=/; secure; HttpOnly
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "total": 2,
+          "subtotal": 1,
+          "page": 1,
+          "per_page": 999999,
+          "search": "name=\"Test Corporation\"",
+          "sort": {
+            "by": null,
+            "order": null
+          },
+          "results": [{"label":"testcorp","created_at":"2016-12-01 19:35:26 UTC","updated_at":"2017-03-27 18:36:51 UTC","id":3,"name":"Test Corporation","title":"Test Corporation","description":"Testing today for a better tomorrow"}]
+        }
+    http_version:
+  recorded_at: Thu, 06 Apr 2017 01:37:35 GMT
+- request:
+    method: get
+    uri: https://admin:changeme@devel.example.com:50083/katello/api/organizations?per_page=999999&search=name=%22Test%20Corporation%22
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      Content-Type:
+      - application/json
+      Accept-Language:
+      - en
+      Host:
+      - devel.example.com:50083
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
       - Thu, 06 Apr 2017 01:37:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)

--- a/test/resources/activation_keys_test.rb
+++ b/test/resources/activation_keys_test.rb
@@ -22,8 +22,8 @@ Options:
  --itemized-subscriptions      Export one subscription per row, only process update subscriptions on import
  --organization ORGANIZATION   Only process organization matching this name
  --search SEARCH               Only export search results
- -h, --help                    print help
- -v, --verbose                 be verbose
+ -h, --help                    Print help
+ -v, --verbose                 Be verbose
 HELP
       stop_vcr
     end

--- a/test/resources/compute_resources_test.rb
+++ b/test/resources/compute_resources_test.rb
@@ -22,8 +22,8 @@ Options:
  --file FILE_NAME              CSV file (default to /dev/stdout with --export, otherwise required)
  --organization ORGANIZATION   Only process organization matching this name
  --search SEARCH               Only export search results
- -h, --help                    print help
- -v, --verbose                 be verbose
+ -h, --help                    Print help
+ -v, --verbose                 Be verbose
 HELP
       stop_vcr
     end

--- a/test/resources/content_hosts_test.rb
+++ b/test/resources/content_hosts_test.rb
@@ -25,8 +25,8 @@ Options:
  --itemized-subscriptions      Export one subscription per row, only process update subscriptions on import
  --organization ORGANIZATION   Only process organization matching this name
  --search SEARCH               Only export search results
- -h, --help                    print help
- -v, --verbose                 be verbose
+ -h, --help                    Print help
+ -v, --verbose                 Be verbose
 
 Columns:
  Name - Name of resource

--- a/test/resources/content_view_filters_test.rb
+++ b/test/resources/content_view_filters_test.rb
@@ -26,8 +26,8 @@ Options:
  --file FILE_NAME              CSV file (default to /dev/stdout with --export, otherwise required)
  --organization ORGANIZATION   Only process organization matching this name
  --search SEARCH               Only export search results
- -h, --help                    print help
- -v, --verbose                 be verbose
+ -h, --help                    Print help
+ -v, --verbose                 Be verbose
 HELP
       stop_vcr
     end

--- a/test/resources/content_views_test.rb
+++ b/test/resources/content_views_test.rb
@@ -25,8 +25,8 @@ Options:
  --file FILE_NAME              CSV file (default to /dev/stdout with --export, otherwise required)
  --organization ORGANIZATION   Only process organization matching this name
  --search SEARCH               Only export search results
- -h, --help                    print help
- -v, --verbose                 be verbose
+ -h, --help                    Print help
+ -v, --verbose                 Be verbose
 HELP
       stop_vcr
     end

--- a/test/resources/domains_test.rb
+++ b/test/resources/domains_test.rb
@@ -22,8 +22,8 @@ Options:
  --file FILE_NAME              CSV file (default to /dev/stdout with --export, otherwise required)
  --organization ORGANIZATION   Only process organization matching this name
  --search SEARCH               Only export search results
- -h, --help                    print help
- -v, --verbose                 be verbose
+ -h, --help                    Print help
+ -v, --verbose                 Be verbose
 HELP
       stop_vcr
     end

--- a/test/resources/products_test.rb
+++ b/test/resources/products_test.rb
@@ -24,8 +24,8 @@ Options:
  --file FILE_NAME              CSV file (default to /dev/stdout with --export, otherwise required)
  --organization ORGANIZATION   Only process organization matching this name
  --search SEARCH               Only export search results
- -h, --help                    print help
- -v, --verbose                 be verbose
+ -h, --help                    Print help
+ -v, --verbose                 Be verbose
 HELP
       stop_vcr
     end

--- a/test/resources/settings_test.rb
+++ b/test/resources/settings_test.rb
@@ -21,8 +21,8 @@ Options:
  --file FILE_NAME              CSV file (default to /dev/stdout with --export, otherwise required)
  --organization ORGANIZATION   Only process organization matching this name
  --search SEARCH               Only export search results
- -h, --help                    print help
- -v, --verbose                 be verbose
+ -h, --help                    Print help
+ -v, --verbose                 Be verbose
 HELP
       stop_vcr
     end

--- a/test/resources/subnets_test.rb
+++ b/test/resources/subnets_test.rb
@@ -22,8 +22,8 @@ Options:
  --file FILE_NAME              CSV file (default to /dev/stdout with --export, otherwise required)
  --organization ORGANIZATION   Only process organization matching this name
  --search SEARCH               Only export search results
- -h, --help                    print help
- -v, --verbose                 be verbose
+ -h, --help                    Print help
+ -v, --verbose                 Be verbose
 HELP
       stop_vcr
     end

--- a/test/resources/subscriptions_test.rb
+++ b/test/resources/subscriptions_test.rb
@@ -21,8 +21,8 @@ Options:
  --file FILE_NAME              CSV file (default to /dev/stdout with --export, otherwise required)
  --organization ORGANIZATION   Only process organization matching this name
  --search SEARCH               Only export search results
- -h, --help                    print help
- -v, --verbose                 be verbose
+ -h, --help                    Print help
+ -v, --verbose                 Be verbose
 HELP
       stop_vcr
     end


### PR DESCRIPTION
Command "hammer csv content-hosts" create empty csv file (with headers only) when organization is not in the results returned by API GET organization with full_results=True, seems a limit of 20 records is enforced.

Fix related to bug: https://bugzilla.redhat.com/show_bug.cgi?id=1535565 

